### PR TITLE
Change dropdown links to take full width

### DIFF
--- a/htdocs/styles/css/minimal/navigation/nav_minimal.css
+++ b/htdocs/styles/css/minimal/navigation/nav_minimal.css
@@ -86,7 +86,6 @@
 
 #nav_main li ul a {
     display: block;
-    float:left;
     clear: both;
     padding: 1em 1.6em;
 }


### PR DESCRIPTION
...to improve small but very irritating UX glitch.

I'm done with clicking those empty areas next to links. :P

Before:
![image](https://cloud.githubusercontent.com/assets/87168/12459481/bd1e08e4-bf63-11e5-8602-e7da5fa143ca.png)

After:
![image](https://cloud.githubusercontent.com/assets/87168/12459488/c7d2e71e-bf63-11e5-9b55-7c0c972600f4.png)
