### PR TITLE
Add support for bcrypt passwords

### DIFF
--- a/module/Auth/config/security.yml
+++ b/module/Auth/config/security.yml
@@ -13,6 +13,12 @@ security:
             algorithm: bcrypt
             cost: 12
 
+        # Stronger password cost for privileged members. See
+        # Rox\Auth\Factory\EncoderFactory
+        harsh:
+            algorithm: bcrypt
+            cost: 13
+
     firewalls:
         default:
             remember_me:

--- a/module/Auth/config/security.yml
+++ b/module/Auth/config/security.yml
@@ -4,8 +4,14 @@ security:
             id: Rox\Auth\Provider\UserProvider
 
     encoders:
-        Rox\Member\Model\Member:
+        # For the legacy MySQL PASSWORD()
+        Rox\Auth\Encoder\LegacyPasswordEncoder:
             id: Rox\Auth\Encoder\LegacyPasswordEncoder
+
+        # Default for all members
+        Rox\Member\Model\Member:
+            algorithm: bcrypt
+            cost: 12
 
     firewalls:
         default:

--- a/module/Auth/config/security.yml
+++ b/module/Auth/config/security.yml
@@ -1,3 +1,12 @@
+# The remember_me parameters below are extracted so they can be used to
+# configure the remember_me feature of the firewall (below), and also be
+# fetched by the ChangePasswordController to check for remember_me cookie.
+parameters:
+    # Checkbox name in form
+    remember_me.form_parameter: remember
+    # Cookie name
+    remember_me.cookie_name: remember_me
+
 security:
     providers:
         Rox\Auth\Provider\UserProvider:
@@ -25,7 +34,8 @@ security:
                 secret: '%kernel.secret%'
                 lifetime: 31536000 # 1 year in seconds
                 path: /
-                remember_me_parameter: remember
+                remember_me_parameter: %remember_me.form_parameter%
+                name: %remember_me.cookie_name%
 
             anonymous: ~
             form_login:

--- a/module/Auth/config/services.yml
+++ b/module/Auth/config/services.yml
@@ -19,3 +19,13 @@ services:
         autowire: true
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 255 }
+
+    Rox\Auth\Listener\AuthListener:
+        class: Rox\Auth\Listener\AuthListener
+        autowire: true
+        tags:
+            - { name: kernel.event_listener, event: security.interactive_login, method: onAuthenticationSuccess }
+
+    Rox\Auth\Factory\EncoderFactory:
+        class: Rox\Auth\Factory\EncoderFactory
+        arguments: ['@security.encoder_factory']

--- a/module/Auth/src/Factory/EncoderFactory.php
+++ b/module/Auth/src/Factory/EncoderFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rox\Auth\Factory;
+
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Decorator for the default encoder factory to adapt for different user
+ * privilege levels and stronger cost password encoders.
+ */
+class EncoderFactory implements EncoderFactoryInterface
+{
+    /**
+     * @var EncoderFactoryInterface
+     */
+    protected $encoderFactory;
+
+    public function __construct(EncoderFactoryInterface $encoderFactory)
+    {
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function getEncoder($user)
+    {
+        // Use the class name of the user to get the intended default encoder
+        $encoderName = get_class($user);
+
+        // If the user is privileged, escalate the encoder to 'harsh'
+        if ($this->isPrivileged($user)) {
+            $encoderName = 'harsh';
+        }
+
+        $encoder = $this->encoderFactory->getEncoder($encoderName);
+
+        return $encoder;
+    }
+
+    protected function isPrivileged(UserInterface $user)
+    {
+        foreach ($user->getRoles() as $role) {
+            if (preg_match('/ROLE_ADMIN.*/', $role)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/module/Auth/src/Listener/AuthListener.php
+++ b/module/Auth/src/Listener/AuthListener.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Rox\Auth\Listener;
+
+use ReflectionObject;
+use Rox\Auth\Factory\EncoderFactory;
+use Rox\Core\Exception\RuntimeException;
+use Rox\Member\Model\Member;
+use Rox\Member\Service\MemberService;
+use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+
+/**
+ * Listens for interactive login (ie. from the login form, when a password
+ * has been typed) to validate that the stored password hash adheres to
+ * current encoder rules (using PHP's password_needs_rehash() function.) If
+ * the check fails, the password is re-encoded with the new encoder by
+ * calling changePassword on MemberService.
+ */
+class AuthListener
+{
+    /**
+     * @var MemberService
+     */
+    protected $memberService;
+
+    /**
+     * @var EncoderFactoryInterface
+     */
+    protected $encoderFactory;
+
+    public function __construct(EncoderFactory $encoderFactory, MemberService $memberService)
+    {
+        $this->memberService = $memberService;
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function onAuthenticationSuccess(InteractiveLoginEvent $e)
+    {
+        $token = $e->getAuthenticationToken();
+
+        /** @var Member $user */
+        $user = $token->getUser();
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        // Get the cost from the encoder
+        $cost = $this->getCost($encoder);
+
+        $isRehashRequired = password_needs_rehash(
+            $user->getPassword(),
+            PASSWORD_DEFAULT,
+            [
+                'cost' => $cost,
+            ]
+        );
+
+        if (!$isRehashRequired) {
+            return;
+        }
+
+        $password = $e->getRequest()->request->get('password');
+
+        if (!$password) {
+            throw new RuntimeException('Could not extract password from interactive login request.');
+        }
+
+        $this->memberService->changePassword($user, $password);
+    }
+
+    /**
+     * We need to know what the defined cost is for a given
+     * BCryptPasswordEncoder. The cost property is not public, so we use
+     * reflection to extract it.
+     *
+     * @param PasswordEncoderInterface $encoder
+     *
+     * @return integer
+     *
+     * @throws RuntimeException
+     */
+    protected function getCost(PasswordEncoderInterface $encoder)
+    {
+        if (!$encoder instanceof BCryptPasswordEncoder) {
+            throw new RuntimeException('Encoder for getCost() is not BCrypt.');
+        }
+
+        $refl = new ReflectionObject($encoder);
+
+        $property = $refl->getProperty('cost');
+
+        $property->setAccessible(true);
+
+        $cost = $property->getValue($encoder);
+
+        $property->setAccessible(false);
+
+        return $cost;
+    }
+}

--- a/module/Core/src/Exception/RuntimeException.php
+++ b/module/Core/src/Exception/RuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rox\Core\Exception;
+
+use RuntimeException as BaseRuntimeException;
+
+class RuntimeException extends BaseRuntimeException implements ExceptionInterface
+{
+}

--- a/module/Member/config/controllers.yml
+++ b/module/Member/config/controllers.yml
@@ -14,3 +14,11 @@ services:
 
     Rox\Member\Controller\HttpsCheckController:
         class: Rox\Member\Controller\HttpsCheckController
+
+    Rox\Member\Controller\ChangePasswordController:
+        class: Rox\Member\Controller\ChangePasswordController
+        parent: Rox\Core\Controller\AbstractController
+        arguments: ['@Rox\Member\Service\MemberService', '@security.encoder_factory', '@security.authentication.rememberme.services.simplehash.default']
+        calls:
+            - [setRememberMeFormParameter, ['%remember_me.form_parameter%']]
+            - [setRememberMeCookieName, ['%remember_me.cookie_name%']]

--- a/module/Member/config/routes.yml
+++ b/module/Member/config/routes.yml
@@ -33,3 +33,9 @@ https_check:
     methods: [GET]
     defaults:
         _controller: Rox\Member\Controller\HttpsCheckController:__invoke
+
+member/change_password:
+    path: /member/password
+    methods: [POST]
+    defaults:
+        _controller: Rox\Member\Controller\ChangePasswordController:changePassword

--- a/module/Member/config/services.yml
+++ b/module/Member/config/services.yml
@@ -25,3 +25,7 @@ services:
     Rox\Member\Service\PreferenceService:
         class: Rox\Member\Service\PreferenceService
         autowire: true
+
+    Rox\Member\Service\MemberService:
+        class: Rox\Member\Service\MemberService
+        arguments: ['@Rox\Auth\Factory\EncoderFactory']

--- a/module/Member/src/Controller/ChangePasswordController.php
+++ b/module/Member/src/Controller/ChangePasswordController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Rox\Member\Controller;
+
+use Rox\Core\Controller\AbstractController;
+use Rox\Member\Service\MemberService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
+
+class ChangePasswordController extends AbstractController
+{
+    /**
+     * @var MemberService
+     */
+    protected $memberService;
+
+    /**
+     * @var EncoderFactoryInterface
+     */
+    protected $encoderFactory;
+
+    /**
+     * @var RememberMeServicesInterface
+     */
+    protected $rememberMeServices;
+
+    /**
+     * @var string
+     */
+    protected $rememberMeFormParameter;
+
+    /**
+     * @var string
+     */
+    protected $rememberMeCookieName;
+
+    public function __construct(
+        MemberService $memberService,
+        EncoderFactoryInterface $encoderFactory,
+        RememberMeServicesInterface $rememberMeServices
+    ) {
+        $this->memberService = $memberService;
+        $this->encoderFactory = $encoderFactory;
+        $this->rememberMeServices = $rememberMeServices;
+    }
+
+    /**
+     * @todo This function isn't utilised by a frontend page yet. It is here as
+     * a reminder to regenerate the remember me token using rememberMeServices
+     * whenever a password is changed.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @throws AccessDeniedHttpException
+     */
+    public function changePassword(Request $request)
+    {
+        $member = $this->getMember();
+
+        $encoder = $this->encoderFactory->getEncoder($member);
+
+        if (!$encoder->isPasswordValid(
+            $member->getPassword(),
+            $request->request->get('old_password'),
+            $member->getSalt()
+        )) {
+            throw new AccessDeniedHttpException;
+        }
+
+        $this->memberService->changePassword($member, $request->request->get('password'));
+
+        $response = new Response();
+
+        // If the remember me cookie is set, then regenerate it.
+        if ($request->cookies->has($this->rememberMeCookieName)) {
+            // Hint to rememberMeServices, as if the checkbox was ticked on the login form
+            $request->request->set($this->rememberMeFormParameter, '1');
+
+            $this->rememberMeServices->loginSuccess($request, $response, $this->getTokenStorage()->getToken());
+        }
+
+        $response->setStatusCode(Response::HTTP_NO_CONTENT);
+
+        return $response;
+    }
+
+    /**
+     * @param string $rememberMeFormParameter
+     *
+     * @return $this
+     */
+    public function setRememberMeFormParameter($rememberMeFormParameter)
+    {
+        $this->rememberMeFormParameter = $rememberMeFormParameter;
+
+        return $this;
+    }
+
+    /**
+     * @param string $rememberMeCookieName
+     *
+     * @return $this
+     */
+    public function setRememberMeCookieName($rememberMeCookieName)
+    {
+        $this->rememberMeCookieName = $rememberMeCookieName;
+
+        return $this;
+    }
+}

--- a/module/Member/src/Service/MemberService.php
+++ b/module/Member/src/Service/MemberService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rox\Member\Service;
+
+use Rox\Member\Model\Member;
+use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
+class MemberService
+{
+    /**
+     * @var EncoderFactoryInterface
+     */
+    protected $encoderFactory;
+
+    public function __construct(EncoderFactoryInterface $encoderFactory)
+    {
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function changePassword(Member $member, $password)
+    {
+        // Use the decorated encoder factory to get the ideal encoder for
+        // this user.
+        $encoder = $this->encoderFactory->getEncoder($member);
+
+        $salt = '';
+
+        // Bcrypt creates its own salt, so we only create one for other
+        // encoders, should they be used in the future.
+        if (!$encoder instanceof BCryptPasswordEncoder) {
+            $salt = random_bytes(16);
+        }
+
+        $member->PassWord = $encoder->encodePassword($password, $salt);
+
+        $member->save();
+    }
+}

--- a/module/Member/tests/Unit/Service/MemberServiceTest.php
+++ b/module/Member/tests/Unit/Service/MemberServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rox\Member\Service;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use Rox\Member\Model\Member;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
+
+class MemberServiceTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EncoderFactoryInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $encoderFactory;
+
+    /**
+     * @var MemberService|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $memberService;
+
+    public function setUp()
+    {
+        $this->encoderFactory = $this
+            ->getMockBuilder(EncoderFactoryInterface::class)
+            ->getMock();
+
+        $this->memberService = new MemberService($this->encoderFactory);
+    }
+
+    public function testChangePassword()
+    {
+        /** @var Member|PHPUnit_Framework_MockObject_MockObject $member */
+        $member = $this->getMockBuilder(Member::class)->getMock();
+
+        $password = base64_encode(random_bytes(32));
+
+        $encoder = $this->createMock(PasswordEncoderInterface::class);
+
+        $passwordHash = 'fakeencoded';
+
+        $encoder
+            ->expects($this->once())
+            ->method('encodePassword')
+            ->with($password, $this->callback(function ($value) {
+                $value = bin2hex($value);
+
+                return preg_match('/^[0-9a-z]{32}$/', $value);
+            }))
+            ->willReturn($passwordHash);
+
+        $this->encoderFactory->expects($this->once())->method('getEncoder')
+            ->with($member)->willReturn($encoder);
+
+        $member->expects($this->once())->method('__set')
+            ->with('PassWord', $passwordHash);
+
+        $member->expects($this->once())->method('save');
+
+        $this->memberService->changePassword($member, $password);
+    }
+}


### PR DESCRIPTION
* Set bcrypt encoder the default for `Member` objects
* Implement `EncoderAwareInterface` to support `Member` objects using different encoders (bcrypt vs. legacy)
* Listen for `security.interactive_login` events and rehash password if the stored hash doesn't meet defined requirements (checked via [password_needs_rehash](http://php.net/password_needs_rehash))
* Use stronger bcrypt cost for users with ROLE_ADMIN*
* Implement simple changePassword service
* Add a simple ChangePassword controller - mostly to demonstrate the need to regenerate remember_me tokens when the password is changed. Validation etc needs to be revisited when this is implemented on the front end.

The interactive_login listener will rehash a password if either the algorithm or the cost has changed. This means:
* A user with a legacy password hash will automatically be rehashed to bcrypt
* A user with bcrypt of cost 12 who has been promoted to ROLE_ADMIN* since their last login will be automatically be rehashed to bcrypt cost 13
* And vice-versa - removing ROLE_ADMIN* will rehash to bcrypt cost 12 upon next login