### PR TITLE
Fix 'message sent' flash message's translation locale

### DIFF
--- a/src/Controller/MessageController.php
+++ b/src/Controller/MessageController.php
@@ -184,7 +184,7 @@ class MessageController extends BaseMessageController
             $body = $messageForm->get('message')->getData();
 
             $this->messageModel->addMessage($sender, $receiver, null, $subject, $body);
-            $this->addTranslatedFlash('success', 'flash.message.sent');
+            $this->addTranslatedFlash('success', 'flash.message.sent', [], null, $sender->getPreferredLanguage()->getShortcode());
 
             return $this->redirectToRoute('members_profile', ['username' => $receiver->getUsername()]);
         }


### PR DESCRIPTION
This PR aims to close #195.
I explicitly set translation locale for flash in the controller to avoid changing anything else about translator.