### PR TITLE
Fixed wrong error message on password reset

### DIFF
--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -62,7 +62,7 @@ class PasswordController extends AbstractController
                 $member = null;
             }
             if (null === $member) {
-                $form->addError(new FormError($this->getTranslator()->trans('flash.email.reset.password')));
+                $form->addError(new FormError($this->getTranslator()->trans('resetpassworderror')));
             } else {
                 try {
                     $token = $this->passwordModel->generatePasswordResetToken($member);


### PR DESCRIPTION
The wrong wordcode was used when trying to reset your password and not giving an existing username (issue reported to Support by a member). It looks like an appropriate wordcode already exists, so I just changed it.