### PR TITLE
Fixing search by age

### DIFF
--- a/build/search/search.model.php
+++ b/build/search/search.model.php
@@ -387,15 +387,15 @@ LIMIT 1
     {
         $minAge = $maxAge = null;
         $condition = "";
-        if (isset($vars['search-age-minimum']) && ($vars['search-age-minimum'] != 0)) {
+        if (isset($vars['search-age-minimum']) && ($vars['search-age-minimum'] != 0) && ($vars['search-age-minimum'] != 18)) {
             $minAge = $vars['search-age-minimum'];
             $condition .= ' AND m.BirthDate <= (NOW() - INTERVAL ' . $minAge . ' YEAR)';
         }
-        if (isset($vars['search-age-maximum']) && ($vars['search-age-maximum'] != 0)) {
+        if (isset($vars['search-age-maximum']) && ($vars['search-age-maximum'] != 0) && ($vars['search-age-maximum'] != 120)) {
             $maxAge = $vars['search-age-maximum'];
             $condition .= ' AND m.BirthDate >= (NOW() - INTERVAL ' . $maxAge . ' YEAR)';
         }
-        if (!empty($condition) && !($minAge == 18 && $maxAge == 120)) {
+        if (!empty($condition)) {
             $condition .= " AND m.HideBirthDate='No'";
         }
 


### PR DESCRIPTION
Members who give a fake birth date making them more than 120 years old are presently not displayed in search results... There are more of them than one would think, just choosing a funny birth date without thinking it will be an issue. I changed the condition so that setting the min age to 18 and max age to 120 (the widest range available in search parameters, and default one) is the same as setting no condition.
Not sure when the $vars['search-age-minimum'] and $vars['search-age-maximum'] can be set and equal to 0, so I left that condition.