### PR TITLE
#248 Fetching activities with at least 0 minutes runtime (instead of only the ones longer than 1 day)

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -95,5 +95,6 @@ doctrine:
         dql:
             datetime_functions:
                 datediff: App\Doctrine\Functions\DateDiff
+                timestampdiff: App\Doctrine\Functions\TimestampDiff
                 yearweek: App\Doctrine\Functions\YearWeek
                 geodistance: App\Doctrine\Functions\GeoDistance

--- a/src/Doctrine/Functions/TimestampDiff.php
+++ b/src/Doctrine/Functions/TimestampDiff.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Doctrine\Functions;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * TimestampDiffFunction ::= "TIMESTAMPDIFF" "(" ArithmeticPrimary "," ArithmeticPrimary "," ArithmeticPrimary ")".
+ */
+class TimestampDiff extends FunctionNode
+{
+    /**
+     * @var Node|null
+     */
+    public $unit = null;
+
+    /**
+     * @var Node|null
+     */
+    public $firstDatetimeExpression = null;
+
+    /**
+     * @var Node|null
+     */
+    public $secondDatetimeExpression = null;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(Lexer::T_IDENTIFIER);
+        $lexer = $parser->getLexer();
+        $this->unit = $lexer->token['value'];
+        $parser->match(Lexer::T_COMMA);
+        $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->secondDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return 'TIMESTAMPDIFF(' .
+            $this->unit . ', ' .
+            $this->firstDatetimeExpression->dispatch($sqlWalker) . ', ' .
+            $this->secondDatetimeExpression->dispatch($sqlWalker) .
+            ')';
+    }
+}

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -76,7 +76,7 @@ class ActivityRepository extends EntityRepository
             ->join('App:ActivityAttendee', 'aa', Join::WITH, 'aa.activity = a and aa.organizer = 1')
             ->join('App:Member', 'm', Join::WITH, 'aa.attendee = m')
             ->where("m.status = 'Banned'")
-            ->orWhere('DATEDIFF(a.ends, a.starts) > 1')
+            ->orWhere('TIMESTAMPDIFF(MINUTE, a.starts, a.ends) >= 0')
             ->orderBy('a.id', 'desc')
             ->getQuery();
     }


### PR DESCRIPTION
I have changed the filter for those activities:

> `DATEDIFF(a.ends, a.starts) > 1`

to 

> `TIMESTAMPDIFF(MINUTE, a.starts, a.ends) >= 0`

The seemingly simpler approach to use `DATEDIFF(a.ends, a.starts) >= 0` would have lead to the issue, that activities with an end time prior to the start time on the same day would show up. Although this shouldn't be possible at storage logic already, the "> 1" filter was preventing those from showing up, so I kept this logic.

![image](https://github.com/BeWelcome/rox/assets/3023230/62826018-dfc8-45e8-8c81-9ed1ba61e0f0)

Fixes #248 