### PR TITLE
Fixed errors due to missing dependencies

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -15,8 +15,8 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
     sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" "$PHP_INI_DIR/php.ini"
 
 	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images
-	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var build data upload
-	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var build data upload
+	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var build data upload || true
+	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var build data upload || true
 
 	if [ "$APP_ENV" != 'prod' ] && [ -f /certs/localCA.crt ]; then
 		ln -sf /certs/localCA.crt /usr/local/share/ca-certificates/localCA.crt
@@ -33,15 +33,25 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 	fi
 
 	if [ "$APP_ENV" != 'prod' ]; then
-		yarn install --frozen-lock
 		composer install --prefer-dist --no-progress --no-interaction --no-scripts
+		yarn install --frozen-lock
 	fi
 
-    database_host=$(grep '^DB_HOST=' .env | cut -f 2 -d '=')
-    database_port=$(grep '^DB_PORT=' .env | cut -f 2 -d '=')
-    database_name=$(grep '^DB_NAME=' .env | cut -f 2 -d '=')
-    database_user=$(grep '^DB_USER=' .env | cut -f 2 -d '=')
-    database_password=$(grep '^DB_PASS=' .env | cut -f 2 -d '=')
+	if [ -f .env ]; then
+	    database_host=$(grep '^DB_HOST=' .env | cut -f 2 -d '=')
+	    database_port=$(grep '^DB_PORT=' .env | cut -f 2 -d '=')
+	    database_name=$(grep '^DB_NAME=' .env | cut -f 2 -d '=')
+	    database_user=$(grep '^DB_USER=' .env | cut -f 2 -d '=')
+	    database_password=$(grep '^DB_PASS=' .env | cut -f 2 -d '=')
+	fi
+
+	# Fall back to environment variables if .env is absent or values are empty
+	database_host="${database_host:-${DB_HOST}}"
+	database_port="${database_port:-${DB_PORT}}"
+	database_name="${database_name:-${DB_NAME}}"
+	database_user="${database_user:-${DB_USER}}"
+	database_password="${database_password:-${DB_PASS}}"
+
 
 	echo "Waiting for db to be ready..."
 	until mariadb $database_name -u $database_user -p$database_password -h $database_host --port=$database_port -e "select 1" > /dev/null 2>&1; do
@@ -69,8 +79,14 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 		bin/console doctrine:migrations:migrate --no-interaction
 	fi
 
-	# WarmUp translations now database is up to date
-	composer run-script --no-dev post-install-cmd
+    # WarmUp translations now database is up to date
+    if [ "$APP_ENV" != 'prod' ]; then
+        composer run-script post-install-cmd
+        composer dump-autoload --classmap-authoritative
+    else
+        composer run-script --no-dev post-install-cmd
+        composer dump-autoload --classmap-authoritative --no-dev
+    fi
 
     echo "Warmup cache"
     bin/console cache:clear


### PR DESCRIPTION
It bypasses 
```
setfacl: build: Not supported
setfacl: build/forums: Not supported
setfacl: build/forums/forums.model.php: Not supported
...
setfacl: build/members/member.entity.php: Not supported
setfacl: upload: Not supported
setfacl: upload/images: Not supported
```
in case of error.
Fixes yarn dependencies on composer dependencies failure due to wrong order - composer should run first.
Also before the fix composer dump-autoload and composer run-script calls always used --no-dev, even in dev mode. That strips dev packages like hautelook/alice-bundle from the autoloader after installing them.

Additionally I needed
echo "UID=$(id -u)" >> .env
echo "GID=$(id -g)" >> .env
and modify docker-compose.override.yml
```
services:
  app:
    build:
      target: bewelcome_php_dev
    ports:
      - target: 80
        published: 8081
        protocol: tcp
    environment:
      APP_ENV: dev
    user: "${UID}:${GID}"
    volumes:
      - .:/srv/bewelcome
      - vendor:/srv/bewelcome/vendor   # protect vendor from host mount

  mailer:
    ports:
      - target: 80
        published: 1081
        protocol: tcp

volumes:
  vendor:
```
but it is more orbstack-specific. Orbstack is used on MacOS for better speed.