### PR TITLE
Fix broken redirects due to missing Symfony URL generator access for old code

### DIFF
--- a/build/groups/groups.ctrl.php
+++ b/build/groups/groups.ctrl.php
@@ -63,7 +63,7 @@ class GroupsController extends RoxControllerBase
         $group = $this->_getGroupFromRequest();
         if (false === $group || ($group->Type == GroupType::INVITE_ONLY && !$this->_model->getLoggedInMember()))
         {
-            $this->redirectAbsolute($this->router->url('groups_redirect'));
+            return $this->redirectAbsolute($this->router->url('groups_redirect'));
         }
         if (($group->approved <> 1) && !$group->isGroupAdmin($member)) {
             $this->setFlashNotice($this->_model->getWords()->get('group.not.approved.yet'));

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 
 
 	echo "Waiting for db to be ready..."
-	until mariadb $database_name -u $database_user -p$database_password -h $database_host --port=$database_port -e "select 1" > /dev/null 2>&1; do
+	until mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" -e "select 1" > /dev/null 2>&1; do
 		sleep 1
 	done
 
@@ -68,13 +68,13 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
         echo "Importing translations"
 		if [ -f docker/db/word.sql ]; then
             echo "Yepp, really. Importing translations"
-			mariadb $database_name -u $database_user -p$database_password -h $database_host --port=$database_port < docker/db/word.sql
+			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/word.sql
 		fi
 		if [ -f docker/db/geonamesadminunits.sql ]; then
-			mariadb $database_name -u $database_user -p$database_password -h $database_host --port=$database_port < docker/db/geonamesadminunits.sql
+			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/geonamesadminunits.sql
 		fi
 
-		bin/console translations:add:missing > /dev/nul
+		bin/console translations:add:missing > /dev/null
 
 	elif ls -A src/Migrations/*.php > /dev/null 2>&1; then
 		bin/console doctrine:migrations:migrate --no-interaction

--- a/roxlauncher/environmentexplorer.php
+++ b/roxlauncher/environmentexplorer.php
@@ -50,6 +50,10 @@ class EnvironmentExplorer
         $this->_initPVars($settings);
         $this->_initBWGlobals($settings);
 
+        // Make Symfony's URL generator available to legacy code
+        if ($this->urlGenerator !== null) {
+            PVars::register('symfony_url_generator', $this->urlGenerator);
+        }
 
         PSurveillance::setPoint('base_loaded');
 

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -63,7 +63,7 @@ class GroupController extends AbstractController
     {
         /** @var Member|null $member */
         $member = $this->getUser();
-        if ($member !== null && $member->getGroups()) {
+        if (null !== $member && $member->getGroups()) {
             return $this->redirectToRoute('groups_mygroups');
         }
 

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -61,9 +61,9 @@ class GroupController extends AbstractController
     #[Route(path: '/groups/', name: 'groups_redirect', priority: 10)]
     public function redirectToOverviewPage()
     {
-        /** @var Member $member */
+        /** @var Member|null $member */
         $member = $this->getUser();
-        if ($member->getGroups()) {
+        if ($member !== null && $member->getGroups()) {
             return $this->redirectToRoute('groups_mygroups');
         }
 

--- a/tools/routing/requestrouter.class.php
+++ b/tools/routing/requestrouter.class.php
@@ -34,7 +34,7 @@ class RequestRouter implements UrlGeneratorInterface
     {
         if (empty(self::$_routes))
         {
-            require_once(SCRIPT_BASE . 'routes.php');
+            require(SCRIPT_BASE . 'routes.php');
         }
     }
 
@@ -136,9 +136,19 @@ class RequestRouter implements UrlGeneratorInterface
      */
     public function url($route, $vars = array(), $add_base = true)
     {
+        $routeName = $route;
         $route = $this->getRoute($route);
         if (empty($route))
         {
+            // Fall back to Symfony's URL generator for routes not in legacy routes.php
+            $symfonyGenerator = PVars::get()->symfony_url_generator;
+            if ($symfonyGenerator !== false && $symfonyGenerator !== null) {
+                try {
+                    return $symfonyGenerator->generate($routeName, $vars);
+                } catch (\Exception $e) {
+                    // Route not found in Symfony either
+                }
+            }
             return '';
         }
         $url = $route['url'];


### PR DESCRIPTION
also added return as
if (false === $group
... without return causes error when false === group as ->approved can't be called on false
}
if (($group->approved <-- here
