### PR TITLE
Build frontend assets into production image (follow-up to #429)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,15 +94,25 @@ RUN set -eux; \
 	composer install --prefer-dist --no-dev --no-scripts --no-progress --no-suggest; \
 	composer clear-cache
 
-# prevent the reinstallation of node_modules at every changes in the source code
-#COPY package.json yarn.lock webpack.config.js postcss.config.js tailwind.config.js tsconfig.json ./
-#RUN set -eux; \
-#	bun i --frozen-lockfile; \
-#	bun encore production --mode=production
+# Stub var/translations so encore can compile (entrypoint cache warmup fills real translations at runtime)
+RUN mkdir -p var/translations && printf '%s\n' \
+	'// auto-generated stub for image build' \
+	'export const localeFallbacks = {"en":"en"};' \
+	'export const messages = {};' \
+	> var/translations/index.js
+
+# Cache deps install: this layer only re-runs when these files change, not on every source change
+COPY package.json bun.lock webpack.config.js postcss.config.js tailwind.config.js tsconfig.json ./
+# Build assets into public/build, then drop node_modules (not needed at runtime) to shrink the image
+RUN set -eux; \
+	bun i --frozen-lockfile; \
+	bun encore production --mode=production; \
+	rm -rf node_modules
 
 # do not use .env files in production
 COPY .env ./
-RUN composer dump-env prod; \
+RUN set -eux; \
+	composer dump-env prod; \
 	rm .env
 
 RUN set -eux; \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,10 @@ Wait a few minutes for containers to build and start (it might take awhile). Pro
 
 Please read [Useful hints](#useful-hints) section below.
 
+### Stage / production deployment
+
+Production images bake in Composer `vendor/` and Webpack `public/build/` at build time — no host-side `bun encore` step. See [docker/DEPLOYMENT.md](docker/DEPLOYMENT.md).
+
 ## B) Installation step by step of BW-Rox (GNU/Linux)
 
 These steps have been tested on Debian/Ubuntu based systems. Commands,

--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -1,0 +1,34 @@
+# Docker deployment
+
+## Production image (`bewelcome_php`)
+
+The default `docker-compose.yml` builds the **`bewelcome_php`** stage. That image is self-contained:
+
+- **PHP dependencies** — `composer install --no-dev` during `docker build` (`vendor/` in the image).
+- **Frontend assets** — `bun encore production` during `docker build` (`public/build/entrypoints.json` and hashed assets in the image).
+- **No bind mount** — the app runs from baked-in `/srv/bewelcome`; no host `vendor/` or `public/build/` required.
+
+Rebuild and redeploy after PHP or frontend changes:
+
+```bash
+docker compose build app
+docker compose up -d
+```
+
+Verify assets are present in a built image:
+
+```bash
+docker build --target bewelcome_php -t bewelcome/app .
+docker run --rm --entrypoint sh bewelcome/app -c 'test -f public/build/entrypoints.json'
+```
+
+`public/build/` stays gitignored; production must not rely on committing compiled assets.
+
+## Local development
+
+Copy `docker-compose.override.yml.dist` to `docker-compose.override.yml` (see `make install`). That override:
+
+- Builds **`bewelcome_php_dev`**
+- Bind-mounts the repository into `/srv/bewelcome`
+
+The entrypoint runs `bun encore dev` when `APP_ENV` is not `prod`, so asset changes on the host are compiled inside the container during development.


### PR DESCRIPTION
## Summary

Follow-up to #429. The production `bewelcome_php` image was missing `public/build/entrypoints.json`, so Symfony threw a Webpack Encore entrypoints error at runtime.

- Enable the `bun encore production` build in the `bewelcome_php` stage so `public/build/entrypoints.json` and hashed assets are baked into the image.
- Add a tiny `var/translations/index.js` stub before the Encore build so webpack can compile at build time (no DB needed). The entrypoint's runtime cache warmup populates real translations from the database.
- Document the production vs. dev asset workflow in `docker/DEPLOYMENT.md` (linked from `INSTALL.md`).

## Test plan

- [x] `docker build --target bewelcome_php -t bewelcome/app .` succeeds
- [x] `docker run --rm --entrypoint sh bewelcome/app -c 'test -f public/build/entrypoints.json'` passes
- [x] Deployed to alpha.stage: homepage returns HTTP/2 200 and serves hashed `/build/*` assets (no Webpack entrypoints error)
- [x] Dev workflow unchanged (override builds `bewelcome_php_dev`, entrypoint runs `bun encore dev`)

Made with [Cursor](https://cursor.com)