### PR TITLE
Build & publish the BeWelcome app image in CI, and trigger stage deploys

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,104 @@
+name: Build and publish image
+
+# Builds the production (bewelcome_php) image once in CI, pushes it to GHCR with
+# immutable tags, and notifies BeWelcome/sysadmins-infra to deploy. The deploy
+# server then only runs `docker compose pull && up -d` — no on-server build.
+
+on:
+  push:
+    branches: [develop]
+    # Only rebuild when something that ends up in the image actually changes.
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'symfony.lock'
+      - 'package.json'
+      - 'bun.lock'
+      - 'webpack.config.js'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - 'src/**'
+      - 'assets/**'
+      - 'config/**'
+      - 'templates/**'
+      - 'public/**'
+      - 'bin/**'
+      - 'bootstrap/**'
+      - 'routes.php'
+      - '.github/workflows/build-image.yml'
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-image:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Match the 7-char short sha used by docker/metadata-action's `type=sha`
+      # so the deploy payload references the exact tag that was pushed.
+      - name: Compute short sha
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/bewelcome/rox
+          tags: |
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push production image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: bewelcome_php
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Trigger the stage deploy only for develop pushes. Tag (v*) builds publish
+      # SemVer images but are deployed manually/gated from sysadmins-infra.
+      - name: Notify sysadmins-infra to deploy stage
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SYSADMINS_INFRA_DISPATCH_TOKEN }}
+          repository: BeWelcome/sysadmins-infra
+          event-type: rox-image-pushed
+          client-payload: |
+            {
+              "image": "ghcr.io/bewelcome/rox:sha-${{ steps.vars.outputs.short_sha }}@${{ steps.build.outputs.digest }}",
+              "tag": "sha-${{ steps.vars.outputs.short_sha }}",
+              "sha": "${{ github.sha }}",
+              "ref": "${{ github.ref }}",
+              "environment": "stage"
+            }

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,6 +45,12 @@ permissions:
 env:
   IMAGE: ghcr.io/bewelcome/rox
 
+# Serialize per-ref so rapid develop pushes don't race two builds and fire two
+# competing deploy dispatches; the newer push wins.
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build ${{ matrix.arch }}
@@ -148,8 +154,11 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
-      # Match the 7-char short sha used by docker/metadata-action's `type=sha`
-      # so the deploy payload references the exact tag that was pushed.
+      # The recomputed 7-char short sha MUST match docker/metadata-action's
+      # `type=sha` output (default short format = 7 chars). If anyone switches
+      # metadata-action to `format=long`, the `imagetools inspect :sha-<shortsha>`
+      # lookup below (and the deploy payload tag) will no longer match the pushed
+      # tag and must be updated accordingly.
       - name: Compute short sha
         id: vars
         run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
@@ -162,13 +171,25 @@ jobs:
           digest=$(docker buildx imagetools inspect "${{ env.IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
+      # Mint a short-lived installation token for the bewelcome-platform-deployer
+      # GitHub App (installed on sysadmins-infra) to authenticate the cross-repo
+      # dispatch, scoped to just that repo.
+      - name: Mint cross-repo token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: BeWelcome
+          repositories: sysadmins-infra
+
       # Trigger the stage deploy only for develop pushes. Tag (v*) builds publish
       # SemVer images but are deployed manually/gated from sysadmins-infra.
       - name: Notify sysadmins-infra to deploy stage
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.SYSADMINS_INFRA_DISPATCH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: BeWelcome/sysadmins-infra
           event-type: rox-image-pushed
           client-payload: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,8 +1,13 @@
 name: Build and publish image
 
-# Builds the production (bewelcome_php) image once in CI, pushes it to GHCR with
-# immutable tags, and notifies BeWelcome/sysadmins-infra to deploy. The deploy
-# server then only runs `docker compose pull && up -d` — no on-server build.
+# Builds the production (bewelcome_php) image once in CI for both linux/amd64 and
+# linux/arm64, pushes a multi-arch manifest to GHCR with immutable tags, and
+# notifies BeWelcome/sysadmins-infra to deploy. The deploy server then only runs
+# `docker compose pull && up -d` — no on-server build.
+#
+# Each architecture is built on a native runner (no QEMU emulation) and pushed
+# by digest; a final job stitches the per-arch digests into one manifest list so
+# `docker pull` resolves the right arch automatically.
 
 on:
   push:
@@ -37,19 +42,26 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE: ghcr.io/bewelcome/rox
+
 jobs:
-  build-image:
-    name: Build and push image
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # Match the 7-char short sha used by docker/metadata-action's `type=sha`
-      # so the deploy payload references the exact tag that was pushed.
-      - name: Compute short sha
-        id: vars
-        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -62,7 +74,66 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/bewelcome/rox
+          images: ${{ env.IMAGE }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the single-arch image and push it by digest only (no tags yet);
+      # the merge job assembles the tagged multi-arch manifest from these digests.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: bewelcome_php
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest and deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
           tags: |
             type=sha,prefix=sha-
             type=ref,event=branch
@@ -70,20 +141,26 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
-      - name: Build and push production image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: bewelcome_php
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Match the 7-char short sha used by docker/metadata-action's `type=sha`
+      # so the deploy payload references the exact tag that was pushed.
+      - name: Compute short sha
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # Resolve the immutable digest of the freshly pushed manifest list so the
+      # deploy payload (and rollback) pins an exact, arch-agnostic reference.
+      - name: Capture manifest digest
+        id: manifest
+        run: |
+          digest=$(docker buildx imagetools inspect "${{ env.IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       # Trigger the stage deploy only for develop pushes. Tag (v*) builds publish
       # SemVer images but are deployed manually/gated from sysadmins-infra.
@@ -96,7 +173,7 @@ jobs:
           event-type: rox-image-pushed
           client-payload: |
             {
-              "image": "ghcr.io/bewelcome/rox:sha-${{ steps.vars.outputs.short_sha }}@${{ steps.build.outputs.digest }}",
+              "image": "${{ env.IMAGE }}:sha-${{ steps.vars.outputs.short_sha }}@${{ steps.manifest.outputs.digest }}",
               "tag": "sha-${{ steps.vars.outputs.short_sha }}",
               "sha": "${{ github.sha }}",
               "ref": "${{ github.ref }}",

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
 		file \
 		gettext \
 		git \
+		mariadb-client \
 		openssh-client \
 		python3 \
 	;

--- a/README.md
+++ b/README.md
@@ -116,11 +116,16 @@ Redeploy a previous immutable tag from `sysadmins-infra` by pointing the deploy 
 an earlier `ghcr.io/bewelcome/rox:sha-<shortsha>` (the digest is recorded in the
 dispatch payload, so the rollback target is exact).
 
-### Required secret
+### Required secrets
 
-The cross-repo dispatch needs a token with write access to `sysadmins-infra`, stored
-in this repo as the `SYSADMINS_INFRA_DISPATCH_TOKEN` secret (a fine-grained PAT or
-GitHub App token). GHCR push itself uses the built-in `GITHUB_TOKEN`.
+The cross-repo dispatch authenticates as the `bewelcome-platform-deployer` GitHub
+App (installed on `sysadmins-infra`). The workflow mints a short-lived installation
+token at run time from two Actions secrets in this repo:
+
+* `DEPLOY_APP_ID` — the App's ID
+* `DEPLOY_APP_PRIVATE_KEY` — the App's private key
+
+GHCR push itself uses the built-in `GITHUB_TOKEN` (`permissions: packages: write`).
 
 ## Useful links
 * [Writing great Git commit messages](http://chris.beams.io/posts/git-commit/)

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ only runs `docker compose pull && docker compose up -d` — there is no on-serve
 ### How the image is built
 
 The [`build-image`](.github/workflows/build-image.yml) workflow builds the
-production `bewelcome_php` target from the [`Dockerfile`](Dockerfile) and pushes it
-to `ghcr.io/bewelcome/rox`. The image is self-contained: `vendor/` and the compiled
-front-end assets (`public/build/`) are baked in at build time, so it boots with no
-host checkout and no bind-mount of the source tree.
+production `bewelcome_php` target from the [`Dockerfile`](Dockerfile) and pushes a
+multi-arch (`linux/amd64` + `linux/arm64`) manifest to `ghcr.io/bewelcome/rox`. Each
+architecture is built on a native runner (no QEMU) and pushed by digest, then a
+merge job stitches the digests into one tagged manifest list so `docker pull`
+resolves the right arch automatically. The image is self-contained: `vendor/` and
+the compiled front-end assets (`public/build/`) are baked in at build time, so it
+boots with no host checkout and no bind-mount of the source tree.
 
 It runs:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,61 @@ everytime you see a change in either ```package.json``` or ```bun.lock```.
 
 If any ```.scss``` file or a file in ```assets/``` changed a ```make build``` is necessary.
 
+## Production image & deployment :rocket:
+
+The production image is **built in CI, not on the deploy server**. The deploy host
+only runs `docker compose pull && docker compose up -d` — there is no on-server
+`docker compose ... --build` and no `composer install` on the server.
+
+### How the image is built
+
+The [`build-image`](.github/workflows/build-image.yml) workflow builds the
+production `bewelcome_php` target from the [`Dockerfile`](Dockerfile) and pushes it
+to `ghcr.io/bewelcome/rox`. The image is self-contained: `vendor/` and the compiled
+front-end assets (`public/build/`) are baked in at build time, so it boots with no
+host checkout and no bind-mount of the source tree.
+
+It runs:
+
+* on every push to `develop` that touches image-affecting paths (`Dockerfile`,
+  `src/**`, `composer.lock`, `assets/**`, etc.), and
+* on every `v*` tag push.
+
+Tags are produced by `docker/metadata-action`:
+
+| Tag | Meaning |
+| --- | --- |
+| `sha-<shortsha>` | Immutable per-commit pin — **use this to deploy and roll back** |
+| `develop` | Moving pointer to the latest `develop` build (convenience only) |
+| `vX.Y.Z`, `X.Y`, `X` | SemVer tags, published only for `v*` tag pushes |
+
+After a successful push **on `develop`**, the workflow sends a `repository_dispatch`
+(`event_type: rox-image-pushed`) to `BeWelcome/sysadmins-infra`, which deploys the
+new `sha-<shortsha>` image to **stage** automatically. The dispatch is *not* sent for
+`v*` tags — production releases are triggered manually/gated from `sysadmins-infra`.
+
+### Cut a production release
+
+```bash
+git tag vX.Y.Z
+git push --tags
+```
+
+This publishes the SemVer image tags. Promote it to production from the
+`sysadmins-infra` deploy workflow.
+
+### Roll back
+
+Redeploy a previous immutable tag from `sysadmins-infra` by pointing the deploy at
+an earlier `ghcr.io/bewelcome/rox:sha-<shortsha>` (the digest is recorded in the
+dispatch payload, so the rollback target is exact).
+
+### Required secret
+
+The cross-repo dispatch needs a token with write access to `sysadmins-infra`, stored
+in this repo as the `SYSADMINS_INFRA_DISPATCH_TOKEN` secret (a fine-grained PAT or
+GitHub App token). GHCR push itself uses the built-in `GITHUB_TOKEN`.
+
 ## Useful links
 * [Writing great Git commit messages](http://chris.beams.io/posts/git-commit/)
 * [Git crash course](http://git.or.cz/course/svn.html)

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "bs5-lightbox": "^1.8.5",
         "circle-flags": "^2.8.3",
         "sortablejs": "^1.15.7",
-        "webpack-dev-server": "^5.2.4",
+        "webpack-dev-server": "^5.2.5",
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -22,7 +22,7 @@
         "@symfony/ux-translator": "file:vendor/symfony/ux-translator/assets",
         "@symfony/webpack-encore": "^5.3.1",
         "@tailwindcss/forms": "^0.5.11",
-        "@tailwindcss/postcss": "^4.3.0",
+        "@tailwindcss/postcss": "^4.3.1",
         "@tomickigrzegorz/autocomplete": "^3.3.2",
         "@trevoreyre/autocomplete-js": "^3.0.3",
         "@types/geojson": "^7946.0.16",
@@ -34,7 +34,7 @@
         "bootstrap-autohidingnavbar": "github:istvan-ujjmeszaros/bootstrap-autohidingnavbar",
         "bs-custom-file-input": "^1.3.4",
         "chart.js": "^3.9.1",
-        "ckeditor5": "^48.1.1",
+        "ckeditor5": "^48.2.0",
         "cookieconsent": "^3.1.1",
         "croppie": "^2.6.5",
         "dayjs": "^1.11.21",
@@ -73,12 +73,12 @@
         "react-dropzone": "^14.4.1",
         "regenerator-runtime": "^0.13.11",
         "respond.js": "^1.4.2",
-        "sass": "^1.100.0",
+        "sass": "^1.101.0",
         "sass-loader": "^16.0.8",
         "scrolling-tabs-bootstrap-5": "^1.1.1",
         "scrollmagic": "^2.0.9",
         "show-more-read": "tomik23/show-more",
-        "tailwindcss": "^4.3.0",
+        "tailwindcss": "^4.3.1",
         "toastify-js": "^1.12.0",
         "tom-select": "^2.6.1",
         "ts-loader": "^9.6.0",
@@ -93,6 +93,7 @@
   },
   "overrides": {
     "fast-uri": "^3.1.2",
+    "http-proxy-middleware": "^3.0.6",
     "minimatch": "^3.1.3",
     "qs": "^6.15.2",
     "serialize-javascript": "^7.0.2",
@@ -1373,7 +1374,7 @@
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
-    "http-proxy-middleware": ["http-proxy-middleware@2.0.9", "", { "dependencies": { "@types/http-proxy": "^1.17.8", "http-proxy": "^1.18.1", "is-glob": "^4.0.1", "is-plain-obj": "^3.0.0", "micromatch": "^4.0.2" }, "peerDependencies": { "@types/express": "^4.17.13" }, "optionalPeers": ["@types/express"] }, "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q=="],
+    "http-proxy-middleware": ["http-proxy-middleware@3.0.7", "", { "dependencies": { "@types/http-proxy": "^1.17.15", "debug": "^4.3.6", "http-proxy": "^1.18.1", "is-glob": "^4.0.3", "is-plain-object": "^5.0.0", "micromatch": "^4.0.8" } }, "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -1459,9 +1460,9 @@
 
     "is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
 
-    "is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -2447,6 +2448,8 @@
 
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
+    "clone-deep/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "css-loader/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
@@ -2544,8 +2547,6 @@
     "ts-loader/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
-
-    "unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "webpack-cli/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "uuid": "^14",
     "qs": "^6.15.2",
     "tmp": "^0.2.6",
-    "ws": "^8.20.1"
+    "ws": "^8.20.1",
+    "http-proxy-middleware": "^3.0.6"
   },
   "scripts": {
     "encoreWatch": "encore dev --watch"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build-image.yml`: builds the production `bewelcome_php` target from the `Dockerfile` and publishes a **multi-arch (`linux/amd64` + `linux/arm64`)** manifest to `ghcr.io/bewelcome/rox`.
- Triggers on `develop` pushes (image-affecting paths only) and `v*` tags, plus `workflow_dispatch`.
- Tags via `docker/metadata-action`: immutable `sha-<shortsha>` (primary deploy pin), moving `develop` pointer, and SemVer (`vX.Y.Z` / `X.Y` / `X`) on tag pushes.
- On `develop` pushes, sends a `rox-image-pushed` `repository_dispatch` to `BeWelcome/sysadmins-infra` to deploy **stage**, pinned to the multi-arch manifest digest. No dispatch for `v*` tags — prod stays manual/gated in sysadmins-infra.
- Fix the existing `bun audit` CI failure by overriding the transitive `http-proxy-middleware` (via `webpack-dev-server`) to the patched `^3.0.6` (GHSA-64mm-vxmg-q3vj).
- Document the build / deploy / rollback / release flow in the README.

## Multi-arch build
- Two **native** build jobs (`amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`, no QEMU), each pushing by digest with per-arch GHA cache scopes.
- A `merge` job assembles the per-arch digests into one tagged manifest list via `docker buildx imagetools create`, then resolves the manifest-list digest for the deploy payload.

## Deploy auth (GitHub App)
- The cross-repo dispatch authenticates as the `bewelcome-platform-deployer` GitHub App: a short-lived installation token is minted at run time via `actions/create-github-app-token@v1` from secrets `DEPLOY_APP_ID` / `DEPLOY_APP_PRIVATE_KEY`, scoped to `sysadmins-infra`.
- The previous `SYSADMINS_INFRA_DISPATCH_TOKEN` PAT approach has been removed.

## Hardening
- Per-ref `concurrency` guard (`cancel-in-progress: true`) so rapid `develop` pushes don't race two builds + competing deploy dispatches.
- Comment documenting that the recomputed 7-char short sha must match `docker/metadata-action`'s `type=sha` default output.

## Cross-repo contract (must match sysadmins-infra)
- `event_type`: `rox-image-pushed`
- `client_payload`: `image` (manifest ref incl. digest), `tag` (`sha-<shortsha>`), `sha`, `ref`, `environment` (`stage`).

## Notes
- The production image is self-contained (baked `vendor/` + compiled assets), so the deploy host only runs `docker compose pull && up -d` — no on-server build or `composer install`.
- GHCR push uses the built-in `GITHUB_TOKEN` via top-level `permissions: packages: write` (+ `contents: read`), inherited by both jobs.
- Free `ubuntu-24.04-arm` runners require the repo to remain public.
- Does not touch `.github/workflows/ci.yml`.

Closes #433