### PR TITLE
Fix invalid GitHub Action tag refs in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -124,7 +124,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - name: Wait for CI checks on this commit
-        uses: lewagon/wait-on-check-action@v1.11.0
+        uses: lewagon/wait-on-check-action@v1.8.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: 'Build and publish image'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -207,7 +207,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}:sha-${{ needs.merge.outputs.short_sha }}
           format: table


### PR DESCRIPTION
## TL;DR

PR #436 merged with broken action version pins. This fixes the two tags so **Wait for CI** and **Scan image** jobs can run.

## What happened

[#436](https://github.com/BeWelcome/rox/pull/436) was merged before the follow-up fix commits landed on the branch:

| Action | Merged (broken) | Fixed |
|--------|-----------------|-------|
| `aquasecurity/trivy-action` | `@0.30.0` | `@v0.36.0` |
| `lewagon/wait-on-check-action` | `@v1.11.0` | `@v1.8.0` |

Both actions publish tags with a `v` prefix; the merged versions do not exist on GitHub.

The post-merge workflow run failed: https://github.com/BeWelcome/rox/actions/runs/27911010793

## Test plan

- [ ] Merge and confirm **Build and publish image** completes **Wait for CI** and **Scan image** jobs

Made with [Cursor](https://cursor.com)