### PR TITLE
Pin build-image workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -131,7 +131,7 @@ jobs:
           merge-multiple: true
 
       - name: Log in to GitHub Container Registry
-        uses:docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -182,7 +182,7 @@ jobs:
     needs: [merge]
     steps:
       - name: Log in to GitHub Container Registry
-        uses:docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Pin every third-party action in `build-image.yml` to a full commit SHA with a `# tag=…` comment, matching the convention already used in `ci.yml`
- Fix YAML typo on the scan job login step (`uses:` spacing)
## Test plan
- [ ] Merge and confirm **Build and publish image** resolves all actions (no "Unable to resolve action" errors)
- [ ] Confirm build, scan, and deploy jobs complete on `develop`