### PR TITLE
Optimize production Docker image. #383

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,16 @@ db_dumps/
 data/
 var/
 coverage/
+VERSION
+rox_local.ini
+config/reference.php
+docker-compose.override.yml
+docker/db/*.sql
+!docker/db/word.sql
+docker/db/*.zip
+docker/db/*.txt
 public/build/
+public/bundles/
+public/main.js*
+public/service-worker.js*
+public/images/newsletters/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,20 @@
 # the different stages of this Dockerfile are meant to be built into separate images
-# https://docs.docker.com/develop/develop-images/multistage-build/#stop-at-a-specific-build-stage
-# https://docs.docker.com/compose/compose-file/#target
-
-
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=8.4
 ARG FRANKENPHP_VERSION=1.11
 
 
-# "php" stage
-FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION}-alpine AS bewelcome_php
+# Shared PHP/FrankenPHP runtime base.
+FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION}-alpine AS bewelcome_php_base
 
-# persistent / runtime deps
 RUN apk add --no-cache \
 		acl \
 		freetype \
 		libjpeg-turbo \
 		libpng \
 		fcgi \
-		file \
 		gettext \
-		git \
 		mariadb-client \
-		openssh-client \
-		python3 \
 	;
 
 RUN set -eux; \
@@ -40,43 +31,25 @@ RUN set -eux; \
 		opcache \
 	;
 
-RUN set -eux; \
-    apk add --no-cache curl unzip bash; \
-    curl -fsSL https://bun.sh/install -o bun-install.sh; \
-    bash bun-install.sh; \
-    ln -s /root/.bun/bin/bun /usr/local/bin/bun; \
-    rm bun-install.sh
-
-# Verify
-RUN bun --version
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN export PATH="/usr/local/bin:$PATH"
-
 COPY docker/php/conf.d/bewelcome.prod.ini $PHP_INI_DIR/conf.d/bewelcome.ini
 
-# https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
-ENV COMPOSER_ALLOW_SUPERUSER=1
-
-# install Symfony Flex globally to speed up download of Composer packages (parallelized prefetching)
 RUN set -eux; \
-    composer global config --no-plugins allow-plugins.symfony/flex true; \
-    composer global require "symfony/flex" --prefer-dist --no-progress --classmap-authoritative; \
-    composer clear-cache
-ENV PATH="${PATH}:/root/.composer/vendor/bin"
+	ln -sf "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"; \
+	sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" "$PHP_INI_DIR/php.ini"
 
 WORKDIR /srv/bewelcome
 
-# build for production
-ARG APP_ENV=prod
 
-# copy only specifically what we need for production
+# Source snapshot reused by build and development stages.
+FROM bewelcome_php_base AS bewelcome_source
+
 COPY assets assets/
 COPY bin bin/
 COPY build build/
 COPY config config/
 COPY docker docker/
 COPY lib lib/
+COPY Migrations Migrations/
 COPY Mike42 Mike42/
 COPY modules modules/
 COPY pthacks pthacks/
@@ -88,37 +61,97 @@ COPY tools tools/
 COPY translations translations/
 COPY routes.php ./
 COPY rox_docker.ini /srv/bewelcome/rox_local.ini
-
-# prevent the reinstallation of vendors at every changes in the source code
 COPY composer.json composer.lock symfony.lock ./
+COPY package.json bun.lock webpack.config.js postcss.config.js tailwind.config.js tsconfig.json ./
+COPY .env ./
+
+
+# Build PHP dependencies and optimized autoload outside the final runtime.
+FROM bewelcome_php_base AS bewelcome_vendor_deps
+
 RUN set -eux; \
-	composer install --prefer-dist --no-dev --no-scripts --no-progress --no-suggest; \
+	apk add --no-cache curl; \
+	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY composer.json composer.lock symfony.lock ./
+
+RUN set -eux; \
+	COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-dev --no-scripts --no-progress --no-autoloader; \
 	composer clear-cache
 
-# Stub var/translations so encore can compile (entrypoint cache warmup fills real translations at runtime)
+FROM bewelcome_vendor_deps AS bewelcome_vendor
+
+COPY --from=bewelcome_source /srv/bewelcome ./
+
+RUN set -eux; \
+	COMPOSER_ALLOW_SUPERUSER=1 composer dump-autoload --classmap-authoritative --no-dev; \
+	COMPOSER_ALLOW_SUPERUSER=1 composer dump-env prod; \
+	composer clear-cache; \
+	rm -rf /root/.composer /root/.cache/composer
+
+
+# Build frontend assets outside the final runtime.
+FROM bewelcome_php_base AS bewelcome_bun
+
+RUN set -eux; \
+	apk add --no-cache bash curl git openssh-client unzip; \
+	curl -fsSL https://bun.sh/install -o bun-install.sh; \
+	bash bun-install.sh; \
+	ln -s /root/.bun/bin/bun /usr/local/bin/bun; \
+	rm bun-install.sh
+
+FROM bewelcome_bun AS bewelcome_assets
+
+COPY package.json bun.lock ./
+COPY --from=bewelcome_vendor_deps /srv/bewelcome/vendor vendor/
+
+RUN set -eux; \
+	bun i --frozen-lockfile
+
+COPY --from=bewelcome_source /srv/bewelcome ./
+
+# Stub var/translations so encore can compile (entrypoint cache warmup fills real translations at runtime).
 RUN mkdir -p var/translations && printf '%s\n' \
 	'// auto-generated stub for image build' \
 	'export const localeFallbacks = {"en":"en"};' \
 	'export const messages = {};' \
 	> var/translations/index.js
 
-# Cache deps install: this layer only re-runs when these files change, not on every source change
-COPY package.json bun.lock webpack.config.js postcss.config.js tailwind.config.js tsconfig.json ./
-# Build assets into public/build, then drop node_modules (not needed at runtime) to shrink the image
 RUN set -eux; \
-	bun i --frozen-lockfile; \
-	bun encore production --mode=production; \
-	rm -rf node_modules
+	bun encore production --mode=production
 
-# do not use .env files in production
-COPY .env ./
-RUN set -eux; \
-	composer dump-env prod; \
-	rm .env
+
+# Self-contained production image.
+FROM bewelcome_php_base AS bewelcome_php
+
+ENV APP_ENV=prod
+
+COPY --from=bewelcome_source /srv/bewelcome/bin bin/
+COPY --from=bewelcome_source /srv/bewelcome/build build/
+COPY --from=bewelcome_source /srv/bewelcome/config config/
+COPY --from=bewelcome_source /srv/bewelcome/lib lib/
+COPY --from=bewelcome_source /srv/bewelcome/Migrations Migrations/
+COPY --from=bewelcome_source /srv/bewelcome/Mike42 Mike42/
+COPY --from=bewelcome_source /srv/bewelcome/modules modules/
+COPY --from=bewelcome_source /srv/bewelcome/pthacks pthacks/
+COPY --from=bewelcome_source /srv/bewelcome/public public/
+COPY --from=bewelcome_source /srv/bewelcome/roxlauncher roxlauncher/
+COPY --from=bewelcome_source /srv/bewelcome/src src/
+COPY --from=bewelcome_source /srv/bewelcome/templates templates/
+COPY --from=bewelcome_source /srv/bewelcome/tools tools/
+COPY --from=bewelcome_source /srv/bewelcome/translations translations/
+COPY --from=bewelcome_source /srv/bewelcome/routes.php ./
+COPY --from=bewelcome_source /srv/bewelcome/rox_local.ini ./
+COPY --from=bewelcome_source /srv/bewelcome/composer.json ./
+COPY --from=bewelcome_vendor /srv/bewelcome/vendor vendor/
+COPY --from=bewelcome_vendor /srv/bewelcome/.env.local.php ./
+COPY --from=bewelcome_assets /srv/bewelcome/public/build public/build/
+COPY --from=bewelcome_assets /srv/bewelcome/public/main.js /srv/bewelcome/public/service-worker.js public/
 
 RUN set -eux; \
-	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images; \
-	composer dump-autoload --classmap-authoritative --no-dev; \
+	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images public/bundles /config /data; \
+	find public -name '*.map' -type f -delete; \
+	chown -R www-data:www-data var data upload public/bundles /config /data; \
 	chmod +x bin/console; \
 	apk upgrade --no-cache; \
 	sync
@@ -126,27 +159,40 @@ VOLUME /srv/bewelcome/var
 VOLUME /srv/bewelcome/data
 
 COPY docker/frankenphp/Caddyfile /etc/caddy/Caddyfile
-
-HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD ["frankenphp", "php-cli", "-r", "echo 1;"]
-
 COPY docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
+
+USER www-data
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD ["frankenphp", "php-cli", "-r", "echo 1;"]
 
 ENTRYPOINT ["docker-entrypoint"]
 CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]
 
 
-# "php" dev stage
-# depends on the "php" stage above
-FROM bewelcome_php AS bewelcome_php_dev
+# Local development image. The repository is bind-mounted over /srv/bewelcome.
+FROM bewelcome_source AS bewelcome_php_dev
 
-# build for production
-ARG NODE_ENV=production
+ENV APP_ENV=dev
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN set -eux; \
-	apk add --no-cache \
-		make \
-		mysql-client; \
-	chmod a+w $PHP_INI_DIR; \
-	chmod -R a+w /srv/bewelcome/vendor; \
-	chmod -R 777 /srv/bewelcome/var
+	apk add --no-cache bash curl git make mysql-client openssh-client python3 unzip; \
+	curl -fsSL https://bun.sh/install -o bun-install.sh; \
+	bash bun-install.sh; \
+	ln -s /root/.bun/bin/bun /usr/local/bin/bun; \
+	rm bun-install.sh; \
+	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer; \
+	chmod a+w "$PHP_INI_DIR"; \
+	mkdir -p vendor var/cache var/log; \
+	chmod -R a+w vendor; \
+	chmod -R 777 var
+
+COPY docker/frankenphp/Caddyfile /etc/caddy/Caddyfile
+COPY docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD ["frankenphp", "php-cli", "-r", "echo 1;"]
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -11,27 +11,34 @@ ensure_composer_dependencies() {
 		return 0
 	fi
 
-	echo "Installing Composer dependencies (vendor/autoload_runtime.php missing)..."
 	if [ "$APP_ENV" = 'prod' ]; then
-		composer install --prefer-dist --no-dev --no-progress --no-interaction --no-scripts
-	else
-		composer install --prefer-dist --no-progress --no-interaction --no-scripts
+		echo "Missing vendor/autoload_runtime.php in production image; rebuild the image instead of installing dependencies at runtime." >&2
+		exit 1
 	fi
+
+	echo "Installing Composer dependencies (vendor/autoload_runtime.php missing)..."
+	composer install --prefer-dist --no-progress --no-interaction --no-scripts
 }
 
 if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ "$1" = 'ls' ]; then
- 	PHP_INI_RECOMMENDED="$PHP_INI_DIR/php.ini-production"
+	PHP_INI_RECOMMENDED="$PHP_INI_DIR/php.ini-production"
 	if [ "$APP_ENV" != 'prod' ]; then
 		PHP_INI_RECOMMENDED="$PHP_INI_DIR/php.ini-development"
 	fi
-	rm -f "$PHP_INI_DIR/php.ini"
-	ln -s "$PHP_INI_RECOMMENDED" "$PHP_INI_DIR/php.ini"
-    sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" "$PHP_INI_DIR/php.ini"
+	if [ -w "$PHP_INI_DIR" ]; then
+		rm -f "$PHP_INI_DIR/php.ini"
+		ln -s "$PHP_INI_RECOMMENDED" "$PHP_INI_DIR/php.ini"
+		sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" "$PHP_INI_DIR/php.ini"
+	fi
 
-	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images
+	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images public/bundles
 	CURRENT_UID="$(id -u)"
-	setfacl -R -m u:www-data:rwX -m u:"${CURRENT_UID}":rwX var build data upload 2>/dev/null || true
-	setfacl -dR -m u:www-data:rwX -m u:"${CURRENT_UID}":rwX var build data upload 2>/dev/null || true
+	ACL_PATHS="var data upload public/bundles"
+	if [ "$APP_ENV" != 'prod' ]; then
+		ACL_PATHS="$ACL_PATHS build"
+	fi
+	setfacl -R -m u:www-data:rwX -m u:"${CURRENT_UID}":rwX $ACL_PATHS 2>/dev/null || true
+	setfacl -dR -m u:www-data:rwX -m u:"${CURRENT_UID}":rwX $ACL_PATHS 2>/dev/null || true
 	if [ "$APP_ENV" != 'prod' ] && [ -f /certs/localCA.crt ]; then
 		ln -sf /certs/localCA.crt /usr/local/share/ca-certificates/localCA.crt
 		update-ca-certificates
@@ -41,9 +48,11 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 		cp rox_docker.ini rox_local.ini
 	fi
 
-	git config --global --add safe.directory /srv/bewelcome 2>/dev/null || true
-	if [ "$APP_ENV" != 'prod' ] && [ ! -f VERSION ]; then
-		git rev-parse --short HEAD > VERSION
+	if [ "$APP_ENV" != 'prod' ]; then
+		git config --global --add safe.directory /srv/bewelcome 2>/dev/null || true
+		if [ ! -f VERSION ]; then
+			git rev-parse --short HEAD > VERSION
+		fi
 	fi
 
 	if [ "$APP_ENV" != 'prod' ]; then
@@ -79,9 +88,9 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 		bin/console test:database:create --drop --force --no-interaction
 		echo "Database created."
 
-        echo "Importing translations"
+		echo "Importing translations"
 		if [ -f docker/db/word.sql ]; then
-            echo "Yepp, really. Importing translations"
+			echo "Yepp, really. Importing translations"
 			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/word.sql
 		fi
 		if [ -f docker/db/geonamesadminunits.sql ]; then
@@ -90,21 +99,21 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 
 		bin/console translations:add:missing > /dev/null
 
-	elif ls -A src/Migrations/*.php > /dev/null 2>&1; then
+	elif ls -A Migrations/*.php > /dev/null 2>&1; then
 		bin/console doctrine:migrations:migrate --no-interaction
 	fi
 
-    # WarmUp translations now database is up to date
-    if [ "$APP_ENV" != 'prod' ]; then
-        composer run-script post-install-cmd
-        composer dump-autoload --classmap-authoritative
-    else
-        composer run-script --no-dev post-install-cmd
-        composer dump-autoload --classmap-authoritative --no-dev
-    fi
-
-    echo "Warmup cache"
-    bin/console cache:clear
+	# WarmUp translations now database is up to date
+	if [ "$APP_ENV" != 'prod' ]; then
+		composer run-script post-install-cmd
+		composer dump-autoload --classmap-authoritative
+		echo "Warmup cache"
+		bin/console cache:clear
+	else
+		echo "Warmup cache"
+		bin/console cache:clear
+		bin/console assets:install public
+	fi
 
 	if [ "$APP_ENV" != 'prod' ]; then
 		bun encore dev --mode=development


### PR DESCRIPTION
Hi, this PR is towards #383

What changed:
- Split the Docker build into clearer production/dev stages.
- Kept Bun, frontend build dependencies, `node_modules`, source maps, and build caches out of the final production image.
- Production now runs as `www-data`; dev still runs as root for local bind-mount bootstrap.
- Removed `COMPOSER_ALLOW_SUPERUSER` from the final runtime image env.
- Aligned Docker MariaDB config with `10.1.48-MariaDB`.
- Fixed MariaDB 10.1 fresh-volume startup issues found during testing:
  - disabled SSL for local `mariadb` CLI calls,
  - normalized newer dump collation during import,
  - added a small DBAL compatibility middleware for MariaDB 10.1 metadata introspection,
  - removed the unsupported InnoDB spatial index from the GeoNames mapping,
  - copied `Migrations/` into the production image.
