### PR TITLE
Restore footer revision display in Docker production images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # tag=v4.2.2
 
+      - name: Commit metadata for VERSION file
+        id: git
+        run: echo "commit_date=$(git log -1 --format=%aI)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
         with:
@@ -97,6 +101,9 @@ jobs:
           target: bewelcome_php
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            GIT_COMMIT_DATE=${{ steps.git.outputs.commit_date }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,9 @@ RUN set -eux; \
 # Self-contained production image.
 FROM bewelcome_php_base AS bewelcome_php
 
+ARG GIT_SHA=unknown
+ARG GIT_COMMIT_DATE=
+
 ENV APP_ENV=prod
 
 COPY --from=bewelcome_source /srv/bewelcome/bin bin/
@@ -148,10 +151,17 @@ COPY --from=bewelcome_vendor /srv/bewelcome/.env.local.php ./
 COPY --from=bewelcome_assets /srv/bewelcome/public/build public/build/
 COPY --from=bewelcome_assets /srv/bewelcome/public/main.js /srv/bewelcome/public/service-worker.js public/
 
+# Footer revision line reads project-root VERSION (see App\Utilities\VersionInfo).
+# Docker images exclude .git, so we cannot run `make version` here; CI passes the
+# commit SHA/date as build args — same outcome as:
+#   git rev-parse --short HEAD > VERSION
+#   touch -d $(TIME_STAMP) VERSION
 RUN set -eux; \
+	printf '%s\n' "${GIT_SHA}" | cut -c1-7 > VERSION; \
+	if [ -n "${GIT_COMMIT_DATE}" ]; then touch -d "${GIT_COMMIT_DATE}" VERSION; fi; \
 	mkdir -p var/cache var/log data/user/avatars data/gallery/member upload/images public/bundles /config /data; \
 	find public -name '*.map' -type f -delete; \
-	chown -R www-data:www-data var data upload public/bundles /config /data; \
+	chown -R www-data:www-data var data upload public/bundles /config /data VERSION; \
 	chmod +x bin/console; \
 	apk upgrade --no-cache; \
 	sync

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -266,6 +266,7 @@ services:
     rox.twig_extension:
         public: true
         class: App\Twig\Extension
+        autowire: true
         arguments:
             $publicDirectory: '%kernel.project_dir%/public'
         tags: [twig.extension]

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -6,7 +6,7 @@ use App\Form\FeedbackFormType;
 use App\Model\AboutModel;
 use App\Utilities\TranslatedFlashTrait;
 use App\Utilities\TranslatorTrait;
-use Carbon\Carbon;
+use App\Utilities\VersionInfo;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +28,7 @@ class FeedbackController extends AboutBaseController
     #[Route(path: '/contactus')]
     #[Route(path: '/support')]
     #[Route(path: '/feedback', name: 'feedback')]
-    public function feedback(Request $request, AboutModel $aboutModel, TranslatorInterface $translator): Response
+    public function feedback(Request $request, AboutModel $aboutModel, TranslatorInterface $translator, VersionInfo $versionInfo): Response
     {
         $noModal = $request->query->get('no', false);
 
@@ -82,12 +82,7 @@ class FeedbackController extends AboutBaseController
             if ($form->isValid()) {
                 $data['member'] = $member;
                 $data['browser'] = $request->headers->get('User-Agent');
-                $data['version'] = 'no version set';
-                if (file_exists('../VERSION')) {
-                    $version = trim(file_get_contents('../VERSION'));
-                    $versionCreated = Carbon::createFromTimestamp(filemtime('../VERSION'));
-                    $data['version'] = $version . ' (' . $versionCreated . ')';
-                }
+                $data['version'] = $versionInfo->getFormattedForFeedback();
 
                 $data['host'] = $request->headers->get('Host');
                 $aboutModel->sendFeedbackEmail($data);

--- a/src/Twig/Extension.php
+++ b/src/Twig/Extension.php
@@ -3,6 +3,7 @@
 namespace App\Twig;
 
 use App\Utilities\ForumUtilities;
+use App\Utilities\VersionInfo;
 use Carbon\Carbon;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
@@ -38,6 +39,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
         /** @var false|string[] */
         private readonly array $locales,
         private readonly string $publicDirectory,
+        private readonly VersionInfo $versionInfo,
     ) {
     }
 
@@ -284,22 +286,15 @@ class Extension extends AbstractExtension implements GlobalsInterface
 
     public function getGlobals(): array
     {
-        $version = '';
         $locale = 'en';
-        $versionCreated = new Carbon();
 
         if (null !== $this->requestStack->getCurrentRequest()) {
             $locale = $this->requestStack->getSession()->get('locale', 'en');
         }
 
-        if (file_exists('../VERSION')) {
-            $version = trim(file_get_contents('../VERSION'));
-            $versionCreated = Carbon::createFromTimestamp(filemtime('../VERSION'));
-        }
-
         return [
-            'version' => $version,
-            'version_dt' => $versionCreated,
+            'version' => $this->versionInfo->getShortHash(),
+            'version_dt' => $this->versionInfo->getBuiltAt(),
             'title' => 'BeWelcome',
             'locales' => $this->locales,
             'robots' => 'ALL',

--- a/src/Utilities/VersionInfo.php
+++ b/src/Utilities/VersionInfo.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Utilities;
+
+use Carbon\Carbon;
+
+/**
+ * Reads the short git revision and build timestamp from the project-root VERSION file.
+ *
+ * Lion (Deployer) and local dev still create this file via `make version`:
+ *   git rev-parse --short HEAD > VERSION
+ *   touch -d $(TIME_STAMP) VERSION
+ *
+ * Docker production images have no .git checkout, so CI bakes the same file at
+ * image build time (see Dockerfile). Reading from %kernel.project_dir%/VERSION
+ * works on both paths; the old ../VERSION relative path broke under FrankenPHP.
+ */
+final class VersionInfo
+{
+    public function __construct(private readonly string $projectDir)
+    {
+    }
+
+    public function getShortHash(): string
+    {
+        $path = $this->getVersionFilePath();
+        if (!is_readable($path)) {
+            return '';
+        }
+
+        return trim((string) file_get_contents($path));
+    }
+
+    public function getBuiltAt(): Carbon
+    {
+        $path = $this->getVersionFilePath();
+        if (!is_readable($path)) {
+            return new Carbon();
+        }
+
+        return Carbon::createFromTimestamp((int) filemtime($path));
+    }
+
+    public function getFormattedForFeedback(): string
+    {
+        $hash = $this->getShortHash();
+        if ('' === $hash) {
+            return 'no version set';
+        }
+
+        return $hash . ' (' . $this->getBuiltAt() . ')';
+    }
+
+    private function getVersionFilePath(): string
+    {
+        return $this->projectDir . '/VERSION';
+    }
+}


### PR DESCRIPTION
## Summary
- Bake a `VERSION` file (short git SHA + commit timestamp) into production Docker images during CI build.
- Add `VersionInfo` utility to read `%kernel.project_dir%/VERSION` reliably, replacing the broken `../VERSION` path under FrankenPHP.
- Wire footer globals and feedback form version reporting through the shared utility.

## Context
Alpha stage runs `APP_ENV=prod` images that never created `VERSION` (excluded from build context; entrypoint only writes it in dev). The footer revision line went blank after the Docker deploy pipeline landed.

## Test plan
- [ ] Merge to `develop` and wait for CI + image build
- [ ] After stage auto-deploy, verify footer shows e.g. `rev. 2c1891a (2026-06-22 …)` on https://alpha.stage.bewelcome.org
- [ ] On the stage host: `docker compose … exec app cat /srv/bewelcome/VERSION` returns the 7-char short SHA
- [ ] Submit feedback and confirm the email includes the version string


Made with [Cursor](https://cursor.com)