### PR TITLE
Differentiate search location page titles. #364

### DIFF
--- a/templates/search/searchlocations.html.twig
+++ b/templates/search/searchlocations.html.twig
@@ -1,6 +1,8 @@
 {% extends 'base.html.twig' %}
 {% import 'macros.twig' as macros %}
 
+{% block title %}{{ 'search.locations'|trans }}{% endblock %}
+
 {% block javascripts %}
     {{ encore_entry_script_tags('search/loadcontent') }}
     {{ encore_entry_script_tags('search/locations') }}

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Repository\MemberRepository;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+#[Group('integration')]
+class SearchControllerTest extends WebTestCase
+{
+    public function testLoggedInSearchByLocationPageTitleNamesPageBeforeBrand(): void
+    {
+        $client = static::createClient();
+        $member = static::getContainer()->get(MemberRepository::class)->loadUserByIdentifier('member-2');
+
+        self::assertNotNull($member);
+
+        $client->loginUser($member);
+        $crawler = $client->request('GET', '/search/locations');
+
+        $this->assertResponseIsSuccessful();
+        self::assertSame('search.locations | BeWelcome', trim($crawler->filter('title')->text()));
+    }
+}


### PR DESCRIPTION
Fixes #364

- Add a page-specific title for logged-in `/search/locations`
- Add focused controller tests for anonymous and logged-in Search by Location titles

<img width="328" height="82" alt="image" src="https://github.com/user-attachments/assets/115868bc-e5de-4e59-9b66-528ed4dcb641" />
