### PR TITLE
Use PHP PDO for DB readiness check; move mariadb-client to dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk add --no-cache \
 		libpng \
 		fcgi \
 		gettext \
-		mariadb-client \
 	;
 
 RUN set -eux; \
@@ -182,7 +181,7 @@ ENV APP_ENV=dev
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN set -eux; \
-	apk add --no-cache bash curl git make mysql-client openssh-client python3 unzip; \
+	apk add --no-cache bash curl git make mariadb-client openssh-client python3 unzip; \
 	curl -fsSL https://bun.sh/install -o bun-install.sh; \
 	bash bun-install.sh; \
 	ln -s /root/.bun/bin/bun /usr/local/bin/bun; \

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -78,8 +78,15 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 	database_password="${database_password:-${DB_PASS:-bewelcome}}"
 
 	echo "Waiting for db to be ready..."
-	until mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" -e "select 1" > /dev/null 2>&1; do
+	db_wait_seconds=0
+	db_wait_max="${BEWELCOME_DB_READY_MAX_WAIT_SECONDS:-300}"
+	until php -r "new PDO('mysql:host=${database_host};port=${database_port};dbname=${database_name}', '${database_user}', '${database_password}');" > /dev/null 2>&1; do
+		if [ "$db_wait_seconds" -ge "$db_wait_max" ]; then
+			echo "Database not ready after ${db_wait_max}s; aborting." >&2
+			exit 1
+		fi
 		sleep 1
+		db_wait_seconds=$((db_wait_seconds + 1))
 	done
 
 	echo "db ready!"


### PR DESCRIPTION
## Problem

The production image carries `mariadb-client` as an OS dependency solely to run the DB readiness wait loop in `docker-entrypoint.sh`. This creates a fragile coupling — if the package is ever dropped from the base image (as happened in #431), the container fails to start even though the actual DB driver (`pdo_mysql`) is always present.

Additionally, `bewelcome_php_dev` was installing `mysql-client` (a deprecated alias) instead of `mariadb-client`, meaning the dev-only SQL imports could break on newer Alpine versions.

## Solution

- Replace the `mariadb` CLI wait loop with a `php -r "new PDO(...)"` check — no OS dependency, always available since `pdo_mysql` is installed via `install-php-extensions`
- Add a configurable hard timeout via `BEWELCOME_DB_READY_MAX_WAIT_SECONDS` (default 300s), replacing the unbounded loop; aborts with a clear error message on timeout
- Remove `mariadb-client` from `bewelcome_php_base` (production image shrinks slightly)
- Move `mariadb-client` to `bewelcome_php_dev` (replacing `mysql-client`) so the CLI remains available for the dev-only SQL imports on startup

## Test plan

- [ ] Dev environment starts up correctly (`docker compose up`) and DB wait resolves
- [ ] SQL imports (`word.sql`, `geonamesadminunits.sql`) still run in dev
- [ ] Production image builds without `mariadb-client` in the base layer
- [ ] Setting `BEWELCOME_DB_READY_MAX_WAIT_SECONDS=5` with an unreachable DB causes the container to abort after ~5s with the timeout message