### PR TITLE
Fix forum notification email threading

### DIFF
--- a/Migrations/Version20260714110000.php
+++ b/Migrations/Version20260714110000.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260714110000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Store forum notification message IDs for RFC-compliant email threading';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE posts_notificationqueue ADD MessageId VARCHAR(255) DEFAULT NULL, ADD UNIQUE INDEX posts_notificationqueue_message_id_unique (MessageId)');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE posts_notificationqueue DROP INDEX posts_notificationqueue_message_id_unique, DROP MessageId');
+    }
+}

--- a/Migrations/Version20260714110000.php
+++ b/Migrations/Version20260714110000.php
@@ -16,7 +16,7 @@ final class Version20260714110000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE posts_notificationqueue ADD MessageId VARCHAR(255) DEFAULT NULL, ADD UNIQUE INDEX posts_notificationqueue_message_id_unique (MessageId)');
+        $this->addSql('ALTER TABLE posts_notificationqueue ADD COLUMN IF NOT EXISTS MessageId VARCHAR(255) DEFAULT NULL, ADD UNIQUE INDEX IF NOT EXISTS posts_notificationqueue_message_id_unique (MessageId)');
     }
 
     #[Override]

--- a/src/Command/SendNotificationsCommand.php
+++ b/src/Command/SendNotificationsCommand.php
@@ -67,6 +67,7 @@ class SendNotificationsCommand extends Command
 
         $sent = 0;
         if (!empty($scheduledNotifications)) {
+            $notificationReferences = [];
             /** @var PostNotification $scheduled */
             foreach ($scheduledNotifications as $scheduled) {
                 $receiver = $scheduled->getReceiver();
@@ -78,17 +79,32 @@ class SendNotificationsCommand extends Command
                         $this->setTranslatorLocale($receiver);
                         $sender = $this->determineSender($scheduled->getPost());
                         $subject = $this->getSubject($scheduled);
-                        $this->mailer->sendNotificationEmail(
+                        $thread = $scheduled->getPost()->getThread();
+                        $referenceKey = $thread->getId() . '-' . $receiver->getId();
+                        $previousMessageIds = $notificationReferences[$referenceKey]
+                            ??= $notificationQueue->getSentMessageIds($receiver, $thread);
+                        $messageId = \sprintf(
+                            'forum-notification-%d%s',
+                            $scheduled->getId(),
+                            strrchr($sender->getAddress(), '@')
+                        );
+                        $success = $this->mailer->sendNotificationEmail(
                             $sender,
                             $receiver,
                             [
                                 'subject' => $subject,
                                 'notification' => $scheduled,
                                 'datesent' => $scheduled->getCreated(),
+                                'messageId' => $messageId,
+                                'previousMessageIds' => $previousMessageIds,
                             ]
                         );
-                        $notificationStatus = NotificationStatusType::SENT;
-                        ++$sent;
+                        if ($success) {
+                            $notificationStatus = NotificationStatusType::SENT;
+                            $scheduled->setMessageId($messageId);
+                            $notificationReferences[$referenceKey][] = $messageId;
+                            ++$sent;
+                        }
                     } catch (Exception $e) {
                         $io->error($e->getMessage());
                     }

--- a/src/Entity/PostNotification.php
+++ b/src/Entity/PostNotification.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'posts_notificationqueue')]
 #[ORM\Index(name: 'posts_notificationqueue_status', columns: ['Status'])]
+#[ORM\UniqueConstraint(name: 'posts_notificationqueue_message_id_unique', columns: ['MessageId'])]
 #[ORM\Entity(repositoryClass: PostNotificationRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 class PostNotification
@@ -38,6 +39,9 @@ class PostNotification
 
     #[ORM\Column(name: 'TableSubscription', type: 'string', length: 64, nullable: false)]
     private string $tableSubscription = 'NotSet';
+
+    #[ORM\Column(name: 'MessageId', type: 'string', length: 255, nullable: true)]
+    private ?string $messageId = null;
 
     #[ORM\Column(name: 'id', type: 'integer')]
     #[ORM\Id]
@@ -114,6 +118,18 @@ class PostNotification
     public function getTableSubscription(): string
     {
         return $this->tableSubscription;
+    }
+
+    public function setMessageId(?string $messageId): self
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    public function getMessageId(): ?string
+    {
+        return $this->messageId;
     }
 
     public function getId(): int

--- a/src/Repository/PostNotificationRepository.php
+++ b/src/Repository/PostNotificationRepository.php
@@ -3,6 +3,8 @@
 namespace App\Repository;
 
 use App\Doctrine\NotificationStatusType;
+use App\Entity\ForumThread;
+use App\Entity\Member;
 use DateTime;
 use Doctrine\ORM\EntityRepository;
 
@@ -25,8 +27,31 @@ class PostNotificationRepository extends EntityRepository
             ->andWhere('n.created < :date')
             ->setParameter('date', $date)
             ->orderBy('n.created', 'asc')
+            ->addOrderBy('n.id', 'asc')
             ->setMaxResults($batchSize)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSentMessageIds(Member $receiver, ForumThread $thread): array
+    {
+        return $this->createQueryBuilder('n')
+            ->select('n.messageId')
+            ->innerJoin('n.post', 'p')
+            ->where('n.receiver = :receiver')
+            ->setParameter('receiver', $receiver)
+            ->andWhere('p.thread = :thread')
+            ->setParameter('thread', $thread)
+            ->andWhere('n.status = :sent')
+            ->setParameter('sent', NotificationStatusType::SENT)
+            ->andWhere('n.messageId IS NOT NULL')
+            ->orderBy('n.created', 'asc')
+            ->addOrderBy('n.id', 'asc')
+            ->getQuery()
+            ->getSingleColumnResult()
+        ;
     }
 }

--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -144,24 +144,14 @@ class Mailer
 
     public function sendNotificationEmail(Address $sender, Member $receiver, $parameters): bool
     {
-        $notification = $parameters['notification'];
-        $threadMessageId = \sprintf(
-            'forum-thread-%d-member-%d%s',
-            $notification->getPost()->getThread()->getId(),
-            $receiver->getId(),
-            strrchr($sender->getAddress(), '@')
-        );
-        $identificationHeaders = 'newthread' === $notification->getType()
-            ? ['Message-ID' => $threadMessageId]
-            : [
-                'Message-ID' => \sprintf(
-                    'forum-notification-%d%s',
-                    $notification->getId(),
-                    strrchr($sender->getAddress(), '@')
-                ),
-                'In-Reply-To' => $threadMessageId,
-                'References' => $threadMessageId,
-            ];
+        $identificationHeaders = [
+            'Message-ID' => $parameters['messageId'],
+        ];
+        $references = $parameters['previousMessageIds'] ?? [];
+        if ($references) {
+            $identificationHeaders['In-Reply-To'] = $references[array_key_last($references)];
+            $identificationHeaders['References'] = $references;
+        }
 
         return $this->sendTemplateEmail(
             $sender,

--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -144,11 +144,31 @@ class Mailer
 
     public function sendNotificationEmail(Address $sender, Member $receiver, $parameters): bool
     {
+        $notification = $parameters['notification'];
+        $threadMessageId = \sprintf(
+            'forum-thread-%d-member-%d%s',
+            $notification->getPost()->getThread()->getId(),
+            $receiver->getId(),
+            strrchr($sender->getAddress(), '@')
+        );
+        $identificationHeaders = 'newthread' === $notification->getType()
+            ? ['Message-ID' => $threadMessageId]
+            : [
+                'Message-ID' => \sprintf(
+                    'forum-notification-%d%s',
+                    $notification->getId(),
+                    strrchr($sender->getAddress(), '@')
+                ),
+                'In-Reply-To' => $threadMessageId,
+                'References' => $threadMessageId,
+            ];
+
         return $this->sendTemplateEmail(
             $sender,
             $receiver,
             'notifications',
-            $parameters
+            $parameters,
+            $identificationHeaders
         );
     }
 
@@ -322,8 +342,13 @@ class Mailer
      * @param Member|Address        $receiver
      * @param mixed                 $parameters
      */
-    private function sendTemplateEmail($sender, $receiver, string $template, array $parameters): bool
-    {
+    private function sendTemplateEmail(
+        $sender,
+        $receiver,
+        string $template,
+        array $parameters,
+        array $identificationHeaders = [],
+    ): bool {
         $currentLocale = $this->translator->getLocale();
         $success = true;
         $locale = $parameters['receiverLocale'] ?? 'en';
@@ -354,6 +379,10 @@ class Mailer
 
         if (isset($parameters['datesent'])) {
             $email->date($parameters['datesent']);
+        }
+
+        foreach ($identificationHeaders as $name => $ids) {
+            $email->getHeaders()->addIdHeader($name, $ids);
         }
 
         if (!\is_string($sender) && !$sender instanceof Address) {

--- a/tests/Command/SendNotificationsCommandTest.php
+++ b/tests/Command/SendNotificationsCommandTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\SendNotificationsCommand;
+use App\Doctrine\MemberStatusType;
+use App\Doctrine\NotificationStatusType;
+use App\Entity\ForumPost;
+use App\Entity\ForumThread;
+use App\Entity\Language;
+use App\Entity\Member;
+use App\Entity\PostNotification;
+use App\Repository\PostNotificationRepository;
+use App\Service\Mailer;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Translation\Translator;
+
+class SendNotificationsCommandTest extends TestCase
+{
+    public function testFirstThreadedNotificationDoesNotReferenceLegacyRows(): void
+    {
+        [$notification] = $this->createNotifications();
+        $parameters = [];
+        $mailer = $this->createMock(Mailer::class);
+        $mailer
+            ->expects($this->once())
+            ->method('sendNotificationEmail')
+            ->willReturnCallback(static function ($sender, $receiver, array $messageParameters) use (&$parameters): bool {
+                $parameters = $messageParameters;
+
+                return true;
+            })
+        ;
+
+        $tester = $this->createCommandTester([$notification], [], $mailer);
+
+        self::assertSame(Command::SUCCESS, $tester->execute([]));
+        self::assertSame([], $parameters['previousMessageIds']);
+        self::assertSame('forum-notification-501@bewelcome.org', $parameters['messageId']);
+        self::assertSame('forum-notification-501@bewelcome.org', $notification->getMessageId());
+    }
+
+    public function testSuccessfulNotificationBecomesParentOfNextMessage(): void
+    {
+        [$first, $second] = $this->createNotifications();
+        $parameters = [];
+        $mailer = $this->createMock(Mailer::class);
+        $mailer
+            ->expects($this->exactly(2))
+            ->method('sendNotificationEmail')
+            ->willReturnCallback(static function ($sender, $receiver, array $messageParameters) use (&$parameters): bool {
+                $parameters[] = $messageParameters;
+
+                return true;
+            })
+        ;
+
+        $tester = $this->createCommandTester(
+            [$first, $second],
+            ['forum-notification-400@bewelcome.org'],
+            $mailer,
+        );
+
+        self::assertSame(Command::SUCCESS, $tester->execute([]));
+        self::assertSame(
+            ['forum-notification-400@bewelcome.org'],
+            $parameters[0]['previousMessageIds'],
+        );
+        self::assertSame(
+            ['forum-notification-400@bewelcome.org', 'forum-notification-501@bewelcome.org'],
+            $parameters[1]['previousMessageIds'],
+        );
+        self::assertSame('forum-notification-501@bewelcome.org', $first->getMessageId());
+        self::assertSame('forum-notification-502@bewelcome.org', $second->getMessageId());
+        self::assertSame(NotificationStatusType::SENT, $first->getStatus());
+        self::assertSame(NotificationStatusType::SENT, $second->getStatus());
+    }
+
+    public function testFailedNotificationIsNotReferencedByNextMessage(): void
+    {
+        [$first, $second] = $this->createNotifications();
+        $parameters = [];
+        $results = [false, true];
+        $mailer = $this->createMock(Mailer::class);
+        $mailer
+            ->expects($this->exactly(2))
+            ->method('sendNotificationEmail')
+            ->willReturnCallback(static function ($sender, $receiver, array $messageParameters) use (&$parameters, &$results): bool {
+                $parameters[] = $messageParameters;
+
+                return array_shift($results);
+            })
+        ;
+
+        $tester = $this->createCommandTester(
+            [$first, $second],
+            ['forum-notification-400@bewelcome.org'],
+            $mailer,
+        );
+
+        self::assertSame(Command::SUCCESS, $tester->execute([]));
+        self::assertSame(
+            ['forum-notification-400@bewelcome.org'],
+            $parameters[0]['previousMessageIds'],
+        );
+        self::assertSame(
+            ['forum-notification-400@bewelcome.org'],
+            $parameters[1]['previousMessageIds'],
+        );
+        self::assertNull($first->getMessageId());
+        self::assertSame('forum-notification-502@bewelcome.org', $second->getMessageId());
+        self::assertSame(NotificationStatusType::FROZEN, $first->getStatus());
+        self::assertSame(NotificationStatusType::SENT, $second->getStatus());
+        self::assertStringContainsString('Sent 1 messages, skipped 1 messages', $tester->getDisplay());
+    }
+
+    private function createCommandTester(
+        array $notifications,
+        array $sentMessageIds,
+        Mailer $mailer,
+    ): CommandTester {
+        $repository = $this->createMock(PostNotificationRepository::class);
+        $repository
+            ->expects($this->once())
+            ->method('getScheduledNotifications')
+            ->willReturn($notifications)
+        ;
+        $repository
+            ->expects($this->once())
+            ->method('getSentMessageIds')
+            ->willReturn($sentMessageIds)
+        ;
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with(PostNotification::class)
+            ->willReturn($repository)
+        ;
+        $entityManager->expects($this->exactly(\count($notifications)))->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $command = new SendNotificationsCommand(
+            $entityManager,
+            $this->createStub(LoggerInterface::class),
+            $mailer,
+            100,
+        );
+        $command->setTranslator(new Translator('en'));
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * @return list<PostNotification>
+     */
+    private function createNotifications(): array
+    {
+        $language = new Language()->setShortCode('en');
+        $receiver = new Member()
+            ->setId(7)
+            ->setUsername('receiver')
+            ->setEmail('receiver@example.org')
+            ->setStatus(MemberStatusType::ACTIVE)
+        ;
+        new ReflectionProperty($receiver, 'preferredLanguage')->setValue($receiver, $language);
+        $author = new Member()->setId(8)->setUsername('author');
+        $thread = new ForumThread()->setId(42)->setTitle('Forum topic');
+        $post = new ForumPost()
+            ->setId(101)
+            ->setThread($thread)
+            ->setAuthor($author)
+        ;
+
+        return [
+            $this->createNotification(501, $receiver, $post),
+            $this->createNotification(502, $receiver, $post),
+        ];
+    }
+
+    private function createNotification(int $id, Member $receiver, ForumPost $post): PostNotification
+    {
+        $notification = new PostNotification()
+            ->setReceiver($receiver)
+            ->setPost($post)
+            ->setType('reply')
+        ;
+        $notification->onPrePersist();
+        new ReflectionProperty($notification, 'id')->setValue($notification, $id);
+
+        return $notification;
+    }
+}

--- a/tests/Service/MailerTest.php
+++ b/tests/Service/MailerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Translation\Translator;
 
 class MailerTest extends TestCase
 {
-    public function testNewThreadNotificationSetsStableMessageId(): void
+    public function testFirstNotificationStartsThread(): void
     {
         $notification = $this->createNotification('newthread');
         $transport = $this->createMock(MailerInterface::class);
@@ -29,7 +29,7 @@ class MailerTest extends TestCase
             ->with($this->callback(static function (RawMessage $message): bool {
                 self::assertInstanceOf(TemplatedEmail::class, $message);
                 self::assertSame(
-                    '<forum-thread-42-member-7@bewelcome.org>',
+                    '<forum-notification-501@bewelcome.org>',
                     $message->getHeaders()->get('Message-ID')?->getBodyAsString()
                 );
                 self::assertNull($message->getHeaders()->get('In-Reply-To'));
@@ -42,11 +42,15 @@ class MailerTest extends TestCase
         $this->assertTrue($this->createMailer($transport)->sendNotificationEmail(
             new Address('forum@bewelcome.org'),
             $notification->getReceiver(),
-            ['subject' => 'Forum topic', 'notification' => $notification]
+            [
+                'subject' => 'Forum topic',
+                'notification' => $notification,
+                'messageId' => 'forum-notification-501@bewelcome.org',
+            ]
         ));
     }
 
-    public function testReplyNotificationReferencesThreadMessage(): void
+    public function testReplyNotificationReferencesPreviousMessage(): void
     {
         $notification = $this->createNotification('reply');
         $transport = $this->createMock(MailerInterface::class);
@@ -60,11 +64,11 @@ class MailerTest extends TestCase
                     $message->getHeaders()->get('Message-ID')?->getBodyAsString()
                 );
                 self::assertSame(
-                    '<forum-thread-42-member-7@bewelcome.org>',
+                    '<forum-notification-500@bewelcome.org>',
                     $message->getHeaders()->get('In-Reply-To')?->getBodyAsString()
                 );
                 self::assertSame(
-                    '<forum-thread-42-member-7@bewelcome.org>',
+                    '<forum-notification-500@bewelcome.org>',
                     $message->getHeaders()->get('References')?->getBodyAsString()
                 );
 
@@ -75,52 +79,55 @@ class MailerTest extends TestCase
         $this->assertTrue($this->createMailer($transport)->sendNotificationEmail(
             new Address('forum@bewelcome.org'),
             $notification->getReceiver(),
-            ['subject' => 'Re: Forum topic', 'notification' => $notification]
+            [
+                'subject' => 'Re: Forum topic',
+                'notification' => $notification,
+                'messageId' => 'forum-notification-501@bewelcome.org',
+                'previousMessageIds' => ['forum-notification-500@bewelcome.org'],
+            ]
         ));
     }
 
-    public function testLaterNotificationsForSamePostStayDistinctInSameGroupThread(): void
+    public function testLaterNotificationIncludesFullReferenceChain(): void
     {
-        $messages = [];
-        $transport = $this->createStub(MailerInterface::class);
+        $notification = $this->createNotification('reply', 503);
+        $transport = $this->createMock(MailerInterface::class);
         $transport
+            ->expects($this->once())
             ->method('send')
-            ->willReturnCallback(static function (RawMessage $message) use (&$messages): void {
-                $messages[] = $message;
-            })
+            ->with($this->callback(static function (RawMessage $message): bool {
+                self::assertInstanceOf(TemplatedEmail::class, $message);
+                self::assertSame(
+                    '<forum-notification-503@bewelcome.org>',
+                    $message->getHeaders()->get('Message-ID')?->getBodyAsString()
+                );
+                self::assertSame(
+                    '<forum-notification-502@bewelcome.org>',
+                    $message->getHeaders()->get('In-Reply-To')?->getBodyAsString()
+                );
+                self::assertSame(
+                    '<forum-notification-500@bewelcome.org> <forum-notification-501@bewelcome.org> <forum-notification-502@bewelcome.org>',
+                    $message->getHeaders()->get('References')?->getBodyAsString()
+                );
+
+                return true;
+            }))
         ;
-        $mailer = $this->createMailer($transport);
-        $sender = new Address('group@bewelcome.org');
-        $notifications = [
-            $this->createNotification('useredit', 501),
-            $this->createNotification('moderatoraction', 502),
-        ];
 
-        foreach ($notifications as $notification) {
-            $mailer->sendNotificationEmail(
-                $sender,
-                $notification->getReceiver(),
-                ['subject' => $notification->getType(), 'notification' => $notification]
-            );
-        }
-
-        self::assertSame(
-            ['<forum-notification-501@bewelcome.org>', '<forum-notification-502@bewelcome.org>'],
-            array_map(
-                static fn (TemplatedEmail $message): ?string => $message->getHeaders()->get('Message-ID')?->getBodyAsString(),
-                $messages
-            )
-        );
-        foreach ($messages as $message) {
-            self::assertSame(
-                '<forum-thread-42-member-7@bewelcome.org>',
-                $message->getHeaders()->get('In-Reply-To')?->getBodyAsString()
-            );
-            self::assertSame(
-                '<forum-thread-42-member-7@bewelcome.org>',
-                $message->getHeaders()->get('References')?->getBodyAsString()
-            );
-        }
+        $this->assertTrue($this->createMailer($transport)->sendNotificationEmail(
+            new Address('group@bewelcome.org'),
+            $notification->getReceiver(),
+            [
+                'subject' => 'Re: Group topic',
+                'notification' => $notification,
+                'messageId' => 'forum-notification-503@bewelcome.org',
+                'previousMessageIds' => [
+                    'forum-notification-500@bewelcome.org',
+                    'forum-notification-501@bewelcome.org',
+                    'forum-notification-502@bewelcome.org',
+                ],
+            ]
+        ));
     }
 
     private function createMailer(MailerInterface $transport): Mailer

--- a/tests/Service/MailerTest.php
+++ b/tests/Service/MailerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\ForumPost;
+use App\Entity\ForumThread;
+use App\Entity\Member;
+use App\Entity\PostNotification;
+use App\Service\Mailer;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\Translator;
+
+class MailerTest extends TestCase
+{
+    public function testNewThreadNotificationSetsStableMessageId(): void
+    {
+        $notification = $this->createNotification('newthread');
+        $transport = $this->createMock(MailerInterface::class);
+        $transport
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(static function (RawMessage $message): bool {
+                self::assertInstanceOf(TemplatedEmail::class, $message);
+                self::assertSame(
+                    '<forum-thread-42-member-7@bewelcome.org>',
+                    $message->getHeaders()->get('Message-ID')?->getBodyAsString()
+                );
+                self::assertNull($message->getHeaders()->get('In-Reply-To'));
+                self::assertNull($message->getHeaders()->get('References'));
+
+                return true;
+            }))
+        ;
+
+        $this->assertTrue($this->createMailer($transport)->sendNotificationEmail(
+            new Address('forum@bewelcome.org'),
+            $notification->getReceiver(),
+            ['subject' => 'Forum topic', 'notification' => $notification]
+        ));
+    }
+
+    public function testReplyNotificationReferencesThreadMessage(): void
+    {
+        $notification = $this->createNotification('reply');
+        $transport = $this->createMock(MailerInterface::class);
+        $transport
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(static function (RawMessage $message): bool {
+                self::assertInstanceOf(TemplatedEmail::class, $message);
+                self::assertSame(
+                    '<forum-notification-501@bewelcome.org>',
+                    $message->getHeaders()->get('Message-ID')?->getBodyAsString()
+                );
+                self::assertSame(
+                    '<forum-thread-42-member-7@bewelcome.org>',
+                    $message->getHeaders()->get('In-Reply-To')?->getBodyAsString()
+                );
+                self::assertSame(
+                    '<forum-thread-42-member-7@bewelcome.org>',
+                    $message->getHeaders()->get('References')?->getBodyAsString()
+                );
+
+                return true;
+            }))
+        ;
+
+        $this->assertTrue($this->createMailer($transport)->sendNotificationEmail(
+            new Address('forum@bewelcome.org'),
+            $notification->getReceiver(),
+            ['subject' => 'Re: Forum topic', 'notification' => $notification]
+        ));
+    }
+
+    public function testLaterNotificationsForSamePostStayDistinctInSameGroupThread(): void
+    {
+        $messages = [];
+        $transport = $this->createStub(MailerInterface::class);
+        $transport
+            ->method('send')
+            ->willReturnCallback(static function (RawMessage $message) use (&$messages): void {
+                $messages[] = $message;
+            })
+        ;
+        $mailer = $this->createMailer($transport);
+        $sender = new Address('group@bewelcome.org');
+        $notifications = [
+            $this->createNotification('useredit', 501),
+            $this->createNotification('moderatoraction', 502),
+        ];
+
+        foreach ($notifications as $notification) {
+            $mailer->sendNotificationEmail(
+                $sender,
+                $notification->getReceiver(),
+                ['subject' => $notification->getType(), 'notification' => $notification]
+            );
+        }
+
+        self::assertSame(
+            ['<forum-notification-501@bewelcome.org>', '<forum-notification-502@bewelcome.org>'],
+            array_map(
+                static fn (TemplatedEmail $message): ?string => $message->getHeaders()->get('Message-ID')?->getBodyAsString(),
+                $messages
+            )
+        );
+        foreach ($messages as $message) {
+            self::assertSame(
+                '<forum-thread-42-member-7@bewelcome.org>',
+                $message->getHeaders()->get('In-Reply-To')?->getBodyAsString()
+            );
+            self::assertSame(
+                '<forum-thread-42-member-7@bewelcome.org>',
+                $message->getHeaders()->get('References')?->getBodyAsString()
+            );
+        }
+    }
+
+    private function createMailer(MailerInterface $transport): Mailer
+    {
+        return new Mailer(
+            $this->createStub(EntityManagerInterface::class),
+            $this->createStub(UrlGeneratorInterface::class),
+            new Translator('en'),
+            $transport
+        );
+    }
+
+    private function createNotification(string $type, int $id = 501): PostNotification
+    {
+        $receiver = new Member()
+            ->setId(7)
+            ->setUsername('member-7')
+            ->setEmail('member-7@example.org')
+            ->setLocale('en')
+        ;
+        $thread = new ForumThread()->setId(42);
+        $post = new ForumPost()->setId(101)->setThread($thread);
+
+        $notification = new PostNotification()
+            ->setReceiver($receiver)
+            ->setPost($post)
+            ->setType($type)
+        ;
+        new ReflectionProperty($notification, 'id')->setValue($notification, $id);
+
+        return $notification;
+    }
+}


### PR DESCRIPTION
Fixes #288

New-thread notifications now use a specific Message-ID