### PR TITLE
fix(entrypoint): run cache:clear before doctrine:migrations:migrate in prod

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -90,6 +90,16 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 	done
 
 	echo "db ready!"
+
+	# In prod: clear and recompile the Symfony DI container from the current
+	# image's config BEFORE running migrations. Without this, a stale compiled
+	# container (from a previous deploy's var/ volume) that references a renamed
+	# or removed class will crash doctrine:migrations:migrate.
+	if [ "$APP_ENV" = 'prod' ]; then
+		echo "Warmup cache"
+		bin/console cache:clear
+	fi
+
 	if [ "$APP_ENV" != 'prod' ]; then
 		echo "Creating database..."
 		bin/console test:database:create --drop --force --no-interaction
@@ -117,8 +127,6 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 		echo "Warmup cache"
 		bin/console cache:clear
 	else
-		echo "Warmup cache"
-		bin/console cache:clear
 		bin/console assets:install public
 	fi
 


### PR DESCRIPTION
## Problem

On every container start in prod, the entrypoint ran:

```
doctrine:migrations:migrate   ← uses whatever DI container is in var/cache/
cache:clear                    ← rebuilds the DI container from current config
```

When a class is **renamed or removed** between two image versions (e.g. `SubtripOptionsType` → `LegOptionsType` in commit `5dfb743f`), the old compiled DI container cached in the persistent `var/` volume still references the old class name. `doctrine:migrations:migrate` loads this stale container, tries to instantiate the renamed class, and crashes before `cache:clear` ever runs.

This was observed on alpha-stage: every deploy with the new image failed within seconds with:

```
Error thrown while running command "doctrine:migrations:migrate --no-interaction".
Message: "Class "App\Doctrine\SubtripOptionsType" not found"
```

## Fix

Move `cache:clear` to **before** `doctrine:migrations:migrate` in the prod branch. This ensures the DI container is always compiled from the current image's `config/` on every startup, regardless of what's cached in the `var/` volume.

The duplicate `cache:clear` at the end of the prod else-branch is removed (it ran after migrations — too late to help, and now redundant).

`assets:install` is unaffected; it doesn't depend on the DI container.

## Impact

- **Prod**: `cache:clear` runs ~5 seconds earlier (before migrations instead of after). No functional change for a fresh deploy where the DI container is already correct.
- **Dev**: unchanged — dev mode rebuilds the cache differently and was not affected by this bug.

## Note for infra

The sysadmins-infra deploy script currently uses `--renew-anon-volumes` as a workaround for this exact issue (BeWelcome/sysadmins-infra#187). Once this PR is deployed, that flag can be removed and the `var/` volume converted to a named volume so logs persist across deploys.