### PR TITLE
fix: use noreply@ as From address for forum and group notifications

### DIFF
--- a/src/Command/SendNotificationsCommand.php
+++ b/src/Command/SendNotificationsCommand.php
@@ -123,9 +123,9 @@ class SendNotificationsCommand extends Command
     {
         $thread = $post->getThread();
         if ($thread->getGroup()) {
-            $from = new Address('group@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
+            $from = new Address('noreply@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
         } else {
-            $from = new Address('forum@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
+            $from = new Address('noreply@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
         }
 
         return $from;


### PR DESCRIPTION
## Summary

`forum@bewelcome.org` and `group@bewelcome.org` were hardcoded as the `From` address in `SendNotificationsCommand::determineSender()`. Member replies to these notifications were landing in the OTRS raw queue.

Changed both to `noreply@bewelcome.org`, which has a Mailcow Sieve auto-reply configured that responds: *"This mailbox is not monitored."*

## Changes

1 file, 2 lines changed in `src/Command/SendNotificationsCommand.php`.

## Test plan

- [ ] Trigger a forum post notification and confirm `From` header shows `noreply@bewelcome.org`
- [ ] Reply to a notification and confirm auto-reply is received