### PR TITLE
fix: use noreply@ as From address for all notification emails

### DIFF
--- a/src/Command/SendNotificationsCommand.php
+++ b/src/Command/SendNotificationsCommand.php
@@ -123,9 +123,9 @@ class SendNotificationsCommand extends Command
     {
         $thread = $post->getThread();
         if ($thread->getGroup()) {
-            $from = new Address('group@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
+            $from = new Address('noreply@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
         } else {
-            $from = new Address('forum@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
+            $from = new Address('noreply@bewelcome.org', 'BeWelcome - ' . $post->getAuthor()->getUsername());
         }
 
         return $from;

--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -23,8 +23,9 @@ use Twig\Environment;
 class Mailer
 {
     private const NO_REPLY_EMAIL_ADDRESS = 'noreply@bewelcome.org';
-    private const MESSAGE_EMAIL_ADDRESS = 'message@bewelcome.org';
-    private const GROUP_EMAIL_ADDRESS = 'group@bewelcome.org';
+    private const MESSAGE_EMAIL_ADDRESS = 'noreply@bewelcome.org';
+    private const GROUP_EMAIL_ADDRESS   = 'noreply@bewelcome.org';
+    private const FORUM_EMAIL_ADDRESS   = 'noreply@bewelcome.org';
     private const PASSWORD_EMAIL_ADDRESS = 'password@bewelcome.org';
     private const SIGNUP_EMAIL_ADDRESS = 'signup@bewelcome.org';
     private const ACCOUNT_FEEDBACK_ADDRESS = 'account@bewelcome.org';


### PR DESCRIPTION
## Summary

- `MESSAGE_EMAIL_ADDRESS` and `GROUP_EMAIL_ADDRESS` constants in `Mailer.php` were pointing to `message@bewelcome.org` and `group@bewelcome.org` — member replies to notifications were landing in the OTRS raw queue
- `SendNotificationsCommand` also had `forum@bewelcome.org` and `group@bewelcome.org` hardcoded in `determineSender()`
- All updated to `noreply@bewelcome.org`, which has a Mailcow Sieve auto-reply: *"This mailbox is not monitored."*

## Changes

| File | Change |
|------|--------|
| `src/Service/Mailer.php` | `MESSAGE_EMAIL_ADDRESS` → `noreply@`, `GROUP_EMAIL_ADDRESS` → `noreply@`, add `FORUM_EMAIL_ADDRESS = noreply@` |
| `src/Command/SendNotificationsCommand.php` | `determineSender()` — `forum@` and `group@` → `noreply@` |

## Test plan

- [ ] Trigger a forum post notification — confirm `From` is `noreply@bewelcome.org`
- [ ] Trigger a group post notification — confirm `From` is `noreply@bewelcome.org`
- [ ] Trigger a member message notification — confirm `From` is `noreply@bewelcome.org`
- [ ] Reply to any notification — confirm auto-reply received: *"This mailbox is not monitored."*