### PR TITLE
fix(mailer): remove freemail Reply-To to fix rspamd SPOOF_REPLYTO junking

### DIFF
--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -93,6 +93,7 @@ class Mailer
     {
         $parameters['sender'] = $member;
         $parameters['receiver'] = $member;
+        $parameters['reporterEmail'] = $member->getEmail();
         $feedbackCategoryRepository = $this->entityManager->getRepository(FeedbackCategory::class);
         $feedbackCategory = $feedbackCategoryRepository->findOneBy(['name' => 'Comment_issue']);
 
@@ -101,7 +102,6 @@ class Mailer
             new Address($feedbackCategory->getEmailToNotify(), 'Comment Issue'),
             'comment.feedback',
             $parameters,
-            $member->getEmail(),
         );
     }
 
@@ -149,7 +149,9 @@ class Mailer
 
     /**
      * Sends contact/feedback form submissions to the helpdesk queue.
-     * From: is always noreply@bewelcome.org to pass DMARC; the reporter's address goes in Reply-To.
+     * From: noreply@bewelcome.org (passes DMARC). No Reply-To — freemail in Reply-To triggers
+     * SPOOF_REPLYTO+FREEMAIL_REPLYTO_NEQ_FROM in rspamd, scoring ~8 pts and routing to Junk.
+     * The reporter's address is already rendered in the email body by feedback.html.twig.
      */
     public function sendFeedbackEmail($sender, Address $receiver, $parameters): bool
     {
@@ -161,7 +163,6 @@ class Mailer
             $receiver,
             'feedback',
             $parameters,
-            \is_string($sender) ? $sender : null,
         );
     }
 

--- a/templates/emails/comment.feedback.html.twig
+++ b/templates/emails/comment.feedback.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/email.html.twig' %}
 
 {% block content%}
-    <p>The user {{ comment.toMember.username }} provided feedback for a comment:</p>
+    <p>The user {{ comment.toMember.username }} ({{ reporterEmail }}) provided feedback for a comment:</p>
     <p>{{ feedback }}</p>
     <p>Please check the comment here: <a href="{{ url('admin_comment', { to_member: comment.toMember.username, from_member: comment.fromMember.username}) }}">Comment from {{ comment.fromMember.username }}</a></p>
 {% endblock content %}

--- a/tests/Service/MailerTest.php
+++ b/tests/Service/MailerTest.php
@@ -72,9 +72,7 @@ class MailerTest extends TestCase
         $this->assertCount(1, $from);
         $this->assertSame('noreply@bewelcome.org', $from[0]->getAddress(), 'From must be noreply to pass DMARC');
 
-        $replyTo = $captured->getReplyTo();
-        $this->assertCount(1, $replyTo);
-        $this->assertSame('reporter@yahoo.fr', $replyTo[0]->getAddress(), 'Reply-To must be the reporter so staff can reply');
+        $this->assertEmpty($captured->getReplyTo(), 'No Reply-To: freemail Reply-To triggers SPOOF_REPLYTO in rspamd and routes to Junk');
     }
 
     public function testSendFeedbackEmailNullFallbackUsesNoreplyWithNoReplyTo(): void
@@ -155,8 +153,6 @@ class MailerTest extends TestCase
         $this->assertCount(1, $from);
         $this->assertSame('noreply@bewelcome.org', $from[0]->getAddress(), 'From must be noreply to pass DMARC');
 
-        $replyTo = $captured->getReplyTo();
-        $this->assertCount(1, $replyTo);
-        $this->assertSame('member@gmail.com', $replyTo[0]->getAddress(), 'Reply-To must be the member so staff can reply');
+        $this->assertEmpty($captured->getReplyTo(), 'No Reply-To: freemail Reply-To triggers SPOOF_REPLYTO in rspamd and routes to Junk');
     }
 }


### PR DESCRIPTION
## Problem

PR #471 fixed DMARC by switching to `From: noreply@bewelcome.org`, but kept `Reply-To: <reporter@freemail>` so staff could reply directly. This still causes feedback emails to land in Junk — rspamd scores `SPOOF_REPLYTO(6.00) + FREEMAIL_REPLYTO_NEQ_FROM(2.00) = 8 pts` when `Reply-To` domain (yahoo.fr, gmail.com, etc.) differs from `From` domain (bewelcome.org). Combined with baseline spam signals this pushes past the Junk threshold. OTRS only polls INBOX, so submissions are silently lost.

We confirmed 4 emails from 2026-08-05 were stuck in `bw-otrs@bewelcome.org` Junk, including Gabriel's Safety and Software issues reports that triggered this investigation. Those 4 have been manually moved to INBOX via doveadm.

## Fix

Remove `Reply-To` from `sendFeedbackEmail` and `sendCommentReportedFeedbackEmail`. The reporter's email is already shown in the email body by both templates (the `feedback.html.twig` template was already updated in #471; `comment.feedback.html.twig` was not — fixed here by adding `{{ reporterEmail }}`).

OTRS agents can see and copy the reporter's address from the body. For OTRS workflow specifically, agents reply from within OTRS using the queue's system_address, not the raw email Reply button.

## What OTRS routing looks like

All feedback addresses (`abuse@`, `account@`, `bugs@`, etc.) are Mailcow aliases → `bw-otrs@bewelcome.org`. OTRS PostMaster filters match the original `To:` header and route to the correct queue automatically — no change needed there.

## Test plan

- [ ] Run `php bin/phpunit tests/Service/MailerTest.php` — all 3 tests pass
- [ ] Submit a test feedback form with a Yahoo/Gmail address — confirm it arrives in OTRS (not Junk)
- [ ] Report a comment as a user with a freemail address — confirm OTRS ticket is created