### PR TITLE
test(beta): batch A — fixtures, Behat docker profile, PasswordResetTest, CI smoke test

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -114,10 +114,93 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  smoke-test:
+    name: Smoke test (amd64 image)
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # tag=v4.2.2
+
+      - name: Download PHP amd64 digest
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # tag=v4.1.8
+        with:
+          name: digests-php-amd64
+          path: /tmp/digests/php
+
+      - name: Download Nginx amd64 digest
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # tag=v4.1.8
+        with:
+          name: digests-nginx-amd64
+          path: /tmp/digests/nginx
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # tag=v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start stack and check /login → 200
+        run: |
+          PHP_DIGEST=$(find /tmp/digests/php -maxdepth 1 -type f -printf '%f\n' | head -1)
+          WEB_DIGEST=$(find /tmp/digests/nginx -maxdepth 1 -type f -printf '%f\n' | head -1)
+          PHP_IMAGE="${{ env.IMAGE }}@sha256:${PHP_DIGEST}"
+          WEB_IMAGE="${{ env.IMAGE }}@sha256:${WEB_DIGEST}"
+
+          cat > docker-compose.smoke.yml <<EOF
+          services:
+            php:
+              image: ${PHP_IMAGE}
+              healthcheck:
+                test: ["CMD", "docker-healthcheck"]
+                start_period: 90s
+                interval: 10s
+                timeout: 3s
+                retries: 6
+              environment:
+                APP_ENV: prod
+                APP_SECRET: ci-smoke-only-not-a-real-secret
+                BEWELCOME_DEPLOY_ENV: stage
+                web_host: localhost
+                MAILER_DSN: smtp://mailer:1025
+                MAILER_NO_REPLY_ADDRESS: test@example.com
+                MAILER_MESSAGE_ADDRESS: test@example.com
+                MAILER_GROUP_ADDRESS: test@example.com
+                MAILER_PASSWORD_ADDRESS: test@example.com
+                MAILER_SIGNUP_ADDRESS: test@example.com
+                MAILER_ACCOUNT_FEEDBACK_ADDRESS: test@example.com
+                MAILER_REMINDER_ADDRESS: test@example.com
+                MAILER_TERMS_OF_USE_ADDRESS: test@example.com
+                MAILER_NEWSLETTER_ADDRESS: test@example.com
+                SYMFONY_TRUSTED_PROXIES: "127.0.0.1"
+                SYMFONY_TRUSTED_HEADERS: "x-forwarded-for,x-forwarded-proto"
+            web:
+              image: ${WEB_IMAGE}
+              ports:
+                - "8080:80"
+          EOF
+
+          docker compose -f docker-compose.yml -f docker-compose.smoke.yml \
+            up -d php web db mailer
+
+          echo "Waiting for php container to be healthy..."
+          for i in $(seq 1 36); do
+            cid=$(docker compose -f docker-compose.yml -f docker-compose.smoke.yml ps -q php)
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$cid" 2>/dev/null || true)
+            [ "$status" = "healthy" ] && break
+            [ "$i" -eq 36 ] && { echo "Timed out — php never became healthy"; docker compose -f docker-compose.yml -f docker-compose.smoke.yml logs php; exit 1; }
+            sleep 5
+          done
+
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/login)
+          [ "$code" = "200" ] || { echo "Expected 200 from /login, got $code"; exit 1; }
+          echo "Smoke test passed (GET /login → $code)"
+
   merge-php:
     name: Push PHP manifest
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, smoke-test]
     outputs:
       short_sha: ${{ steps.vars.outputs.short_sha }}
       digest: ${{ steps.manifest.outputs.digest }}

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -27,3 +27,10 @@ localhost:
     extensions:
         'Alex\MailCatcher\Behat\MailCatcherExtension\Extension':
             url: http://localhost:1080
+
+docker:
+    extensions:
+        'Behat\MinkExtension':
+            base_url: 'http://web'
+        'Alex\MailCatcher\Behat\MailCatcherExtension\Extension':
+            url: http://mailer:1080

--- a/fixtures/members.yml
+++ b/fixtures/members.yml
@@ -301,9 +301,9 @@ App\Entity\Member:
         bewelcomed: 0
         registration_key: ''
     member_suspended:
-        Username: 'member-suspended'
+        Username: 'member-taken-out'
         BirthDate: <DateTime()>
-        email: 'member-suspended\@bewelcome.org'
+        email: 'member-taken-out\@bewelcome.org'
         created: <dateTimeBetween("-200 days", "now")>
         updated: <dateTimeBetween($created, "now")>
         LastLogin: <dateTimeBetween($created, "now")>
@@ -351,6 +351,157 @@ App\Entity\Member:
         MotivationForHospitality: 0
         HideBirthDate: <boolean(75)>
         AdressHidden: <boolean(75)>
+        WebSite: 0
+        ChatSkype: 0
+        ChatICQ: 0
+        ChatAOL: 0
+        ChatMSN: 0
+        ChatYahoo: 0
+        ChatOthers: 0
+        FutureTrips: 0
+        OldTrips: 0
+        LogCount: 0
+        Hobbies: 0
+        Books: 0
+        Music: 0
+        PastTrips: 0
+        Password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'
+        PlannedTrips: 0
+        PleaseBring: 0
+        OfferGuests: 0
+        OfferHosts: 0
+        PublicTransport: 0
+        Movies: 0
+        ChatGoogle: 0
+        bewelcomed: 0
+        registration_key: ''
+    member_host:
+        Username: 'member-host'
+        BirthDate: <DateTime()>
+        email: 'member-host\@bewelcome.org'
+        created: <dateTimeBetween("-200 days", "now")>
+        updated: <dateTimeBetween($created, "now")>
+        LastLogin: <dateTimeBetween($created, "now")>
+        LastSwitchToActive: null
+        ExUserId: 0
+        Status: 'Active'
+        ChangedId: 0
+        city: '@NewBerlin'
+        Latitude: '@NewBerlin->Latitude'
+        Longitude: '@NewBerlin->Longitude'
+        remindersWithoutLogin: 0
+        HomePhoneNumber: 0
+        CellPhoneNumber: 0
+        WorkPhoneNumber: 0
+        SecEmail: 0
+        HideAttribute: 8
+        FirstName: <firstName()>
+        SecondName: ''
+        LastName: <lastName()>
+        Accommodation: 'anytime'
+        hostingInterest: 8
+        AdditionalAccommodationInfo: 0
+        ILiveWith: 0
+        IdentityCheckLevel: 0
+        InformationToGuest: 0
+        TypicOffer: null
+        Offer: 0
+        MaxGuest: 2
+        MaxLenghtOfStay: 7
+        Organizations: 0
+        Restrictions: 0
+        OtherRestrictions: 0
+        Bday: 1
+        Bmonth: 1
+        Byear: 1985
+        SecurityFlag: 0
+        Quality: 0
+        ProfileSummary: 1
+        Occupation: 1
+        CounterGuests: 0
+        CounterHosts: 0
+        CounterTrusts: 0
+        Gender: 'female'
+        HideGender: false
+        GenderOfGuest: ''
+        MotivationForHospitality: 0
+        HideBirthDate: false
+        AdressHidden: false
+        WebSite: 0
+        ChatSkype: 0
+        ChatICQ: 0
+        ChatAOL: 0
+        ChatMSN: 0
+        ChatYahoo: 0
+        ChatOthers: 0
+        FutureTrips: 0
+        OldTrips: 0
+        LogCount: 0
+        Hobbies: 0
+        Books: 0
+        Music: 0
+        PastTrips: 0
+        Password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'
+        PlannedTrips: 0
+        PleaseBring: 0
+        OfferGuests: 0
+        OfferHosts: 0
+        PublicTransport: 0
+        Movies: 0
+        ChatGoogle: 0
+        bewelcomed: 0
+        registration_key: ''
+    member_guest:
+        Username: 'member-guest'
+        BirthDate: <DateTime()>
+        email: 'member-guest\@bewelcome.org'
+        created: <dateTimeBetween("-200 days", "now")>
+        updated: <dateTimeBetween($created, "now")>
+        LastLogin: <dateTimeBetween($created, "now")>
+        LastSwitchToActive: null
+        ExUserId: 0
+        Status: 'Active'
+        ChangedId: 0
+        city: '@NewJayapura'
+        Latitude: '@NewJayapura->Latitude'
+        Longitude: '@NewJayapura->Longitude'
+        remindersWithoutLogin: 0
+        HomePhoneNumber: 0
+        CellPhoneNumber: 0
+        WorkPhoneNumber: 0
+        SecEmail: 0
+        HideAttribute: 8
+        FirstName: <firstName()>
+        SecondName: ''
+        LastName: <lastName()>
+        Accommodation: 'neverask'
+        AdditionalAccommodationInfo: 0
+        ILiveWith: 0
+        IdentityCheckLevel: 0
+        InformationToGuest: 0
+        TypicOffer: null
+        Offer: 0
+        MaxGuest: 0
+        MaxLenghtOfStay: 0
+        Organizations: 0
+        Restrictions: 0
+        OtherRestrictions: 0
+        Bday: 1
+        Bmonth: 6
+        Byear: 1990
+        SecurityFlag: 0
+        Quality: 0
+        ProfileSummary: 1
+        Occupation: 1
+        CounterGuests: 0
+        CounterHosts: 0
+        CounterTrusts: 0
+        Gender: 'male'
+        HideGender: false
+        GenderOfGuest: ''
+        MotivationForHospitality: 0
+        HideBirthDate: false
+        AdressHidden: false
         WebSite: 0
         ChatSkype: 0
         ChatICQ: 0

--- a/tests/Model/PasswordResetTest.php
+++ b/tests/Model/PasswordResetTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Tests\Model;
+
+use App\Entity\Member;
+use App\Entity\PasswordReset;
+use App\Model\PasswordModel;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+class PasswordResetTest extends TestCase
+{
+    private EntityManagerInterface $entityManager;
+    private PasswordHasherFactoryInterface $passwordHasherFactory;
+    private PasswordModel $passwordModel;
+
+    public function setUp(): void
+    {
+        $this->entityManager = Mockery::mock(EntityManagerInterface::class);
+        $this->passwordHasherFactory = Mockery::mock(PasswordHasherFactoryInterface::class);
+        $this->passwordModel = new PasswordModel($this->entityManager, $this->passwordHasherFactory);
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testGenerateTokenReturnsHexString(): void
+    {
+        $member = new Member();
+        $repo = Mockery::mock(EntityRepository::class);
+        $repo->shouldReceive('findBy')->with(['member' => $member])->andReturn([]);
+        $this->entityManager->shouldReceive('getRepository')->with(PasswordReset::class)->andReturn($repo);
+        $this->entityManager->shouldReceive('persist')->once();
+        $this->entityManager->shouldReceive('flush')->twice();
+
+        $token = $this->passwordModel->generatePasswordResetToken($member);
+
+        $this->assertSame(64, strlen($token));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    public function testGenerateTokenIsUniquePerCall(): void
+    {
+        $member = new Member();
+        $repo = Mockery::mock(EntityRepository::class);
+        $repo->shouldReceive('findBy')->with(['member' => $member])->twice()->andReturn([]);
+        $this->entityManager->shouldReceive('getRepository')->with(PasswordReset::class)->twice()->andReturn($repo);
+        $this->entityManager->shouldReceive('persist')->twice();
+        $this->entityManager->shouldReceive('flush')->times(4);
+
+        $token1 = $this->passwordModel->generatePasswordResetToken($member);
+        $token2 = $this->passwordModel->generatePasswordResetToken($member);
+
+        $this->assertNotSame($token1, $token2);
+    }
+
+    public function testGenerateTokenRemovesExistingTokensFirst(): void
+    {
+        $member = new Member();
+        $existing = new PasswordReset();
+        $repo = Mockery::mock(EntityRepository::class);
+        $repo->shouldReceive('findBy')->with(['member' => $member])->andReturn([$existing]);
+        $this->entityManager->shouldReceive('getRepository')->with(PasswordReset::class)->andReturn($repo);
+        $this->entityManager->shouldReceive('remove')->once()->with($existing);
+        $this->entityManager->shouldReceive('persist')->once();
+        $this->entityManager->shouldReceive('flush')->twice();
+
+        $this->passwordModel->generatePasswordResetToken($member);
+    }
+
+    public function testRemoveTokensDeletesAll(): void
+    {
+        $member = new Member();
+        $token1 = new PasswordReset();
+        $token2 = new PasswordReset();
+        $repo = Mockery::mock(EntityRepository::class);
+        $repo->shouldReceive('findBy')->with(['member' => $member])->andReturn([$token1, $token2]);
+        $this->entityManager->shouldReceive('getRepository')->with(PasswordReset::class)->andReturn($repo);
+        $this->entityManager->shouldReceive('remove')->once()->with($token1);
+        $this->entityManager->shouldReceive('remove')->once()->with($token2);
+        $this->entityManager->shouldReceive('flush')->once();
+
+        $this->passwordModel->removePasswordResetTokens($member);
+    }
+
+    public function testRemoveTokensFlushesEvenWhenNoneExist(): void
+    {
+        $member = new Member();
+        $repo = Mockery::mock(EntityRepository::class);
+        $repo->shouldReceive('findBy')->with(['member' => $member])->andReturn([]);
+        $this->entityManager->shouldReceive('getRepository')->with(PasswordReset::class)->andReturn($repo);
+        $this->entityManager->shouldReceive('remove')->never();
+        $this->entityManager->shouldReceive('flush')->once();
+
+        $this->passwordModel->removePasswordResetTokens($member);
+    }
+
+    public function testGetPasswordHashDelegatesToHasher(): void
+    {
+        $member = new Member();
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+        $hasher->shouldReceive('hash')->with('secret')->andReturn('$2y$13$hashed');
+        $this->passwordHasherFactory->shouldReceive('getPasswordHasher')->with($member)->andReturn($hasher);
+
+        $hash = $this->passwordModel->getPasswordHash($member, 'secret');
+
+        $this->assertSame('$2y$13$hashed', $hash);
+    }
+}


### PR DESCRIPTION
## Summary

- **fixtures/members.yml**: fix `member_suspended` username to `member-taken-out` to match `auth.feature` expectation; add `member_host` (`Accommodation: anytime`) and `member_guest` fixtures needed by upcoming hosting-request Behat scenarios
- **behat.yml.dist**: add `docker` profile (`base_url: http://web`, mailer at `http://mailer:1080`) for running Behat inside the Docker Compose network
- **tests/Model/PasswordResetTest.php**: unit tests for `PasswordModel` — token generation (64-char hex, unique per call, clears existing tokens), `removePasswordResetTokens`, `getPasswordHash`
- **.github/workflows/build-image-beta.yml**: add `smoke-test` job that pulls the amd64 PHP+Nginx images by digest after build, starts the full stack (`php web db mailer`), and asserts `GET /login → 200` before the multi-arch manifest is pushed; `merge-php` now depends on `smoke-test` so a broken image never reaches GHCR

## Test plan

- [ ] CI run passes (smoke-test job starts stack, GET /login returns 200)
- [ ] `vendor/bin/phpunit tests/Model/PasswordResetTest.php` passes
- [ ] `vendor/bin/behat --profile=docker features/auth.feature` passes (member-taken-out fixture now matches)