### PR TITLE
chore(db): bump MariaDB 12.0.2 → 12.3 LTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - php
 
   db:
-    image: mariadb:12.0.2
+    image: mariadb:12.3
     environment:
       MYSQL_ROOT_PASSWORD: bewelcome_root_dev
       MYSQL_DATABASE: bewelcome


### PR DESCRIPTION
## Summary

- Replaces `mariadb:12.0.2` with `mariadb:12.3` in `docker-compose.yml`
- `12.0.2` was the original version set when the Docker setup was first written and was never revisited — not a deliberate choice
- `12.3` is the current LTS release in the 12.x line: accumulated security patches, bug fixes from the early 12.0.x releases, and a committed long-term support window

## Test plan

- [ ] Confirm `docker compose up` starts cleanly with the new image
- [ ] Run the beta migration cycle (`beta-migration-cycle.md`) against the 12.3 container to confirm the existing pre-flight fixes (strict mode, `max_allowed_packet`) still cover everything