### PR TITLE
ci: clarify develop image workflow name

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish image
+name: Build and publish develop image
 
 # Builds the production (bewelcome_php) image once in CI for both linux/amd64 and
 # linux/arm64, pushes a multi-arch manifest to GHCR with immutable tags, scans the


### PR DESCRIPTION
Renames "Build and publish image" to "Build and publish develop image" so it is immediately clear in the Actions tab which branch this workflow serves (develop), distinct from "Build and publish beta image" (feature/docker-beta).