### PR TITLE
ci(trivy): ignore CVE-2026-11940 until Alpine 3.24 backports python3 3.14.7-r0

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,11 @@
-# CVE-2026-58055: nghttp2-libs 1.69.0-r0 — fix is 1.70.0-r0, not yet backported to Alpine 3.24.
+# CVE-2026-58055: nghttp2-libs 1.69.0-r0, fix is 1.70.0-r0, not yet backported to Alpine 3.24.
 # Track: https://pkgs.alpinelinux.org/packages?name=nghttp2&branch=v3.24
 # Remove once Alpine 3.24 ships nghttp2-libs >= 1.70.0-r0.
 CVE-2026-58055
+
+# CVE-2026-11940: pyc/python3 3.14.5-r0 (tarfile filter bypass), fix is 3.14.7-r0, not yet backported to Alpine 3.24.
+# apk upgrade runs at build time but 3.14.7-r0 is not in the 3.24 repo yet.
+# Track: https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.24
+# Remove once Alpine 3.24 ships python3 >= 3.14.7-r0.
+CVE-2026-11940
 


### PR DESCRIPTION
CVE-2026-11940 (HIGH, tarfile filter bypass in cpython) is failing the Trivy scan. The fix version 3.14.7-r0 exists in Alpine edge but is not yet backported to the Alpine 3.24 repo that the image uses. The Dockerfile already runs `apk upgrade` at build time, so this will resolve automatically once 3.24 ships the fix. Track: https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.24