### PR TITLE
feat: Add DevContainer and Codespaces support for docker-master

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+﻿{
+    "name": "BeWelcome Rox (Docker Master)",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../docker-compose.override.yml.dist"
+    ],
+    "service": "php",
+    "workspaceFolder": "/srv/bewelcome",
+    "overrideCommand": false,
+    "forwardPorts": [80, 1080, 9306, 9308],
+    "portsAttributes": {
+        "80": {
+            "label": "BeWelcome App (Nginx)",
+            "onAutoForward": "openBrowser"
+        },
+        "1080": {
+            "label": "MailCatcher Web UI",
+            "onAutoForward": "notify"
+        },
+        "9306": {
+            "label": "Manticore MySQL protocol",
+            "onAutoForward": "silent"
+        },
+        "9308": {
+            "label": "Manticore HTTP API",
+            "onAutoForward": "silent"
+        }
+    },
+    "postCreateCommand": "bzip2 -ckd docker/languages.sql.bz2 > docker/db/languages.sql && bzip2 -ckd docker/words.sql.bz2 > docker/db/words.sql",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bmewburn.vscode-intelephense-client",
+                "xdebug.php-debug",
+                "symfony-vscode.symfony-vscode",
+                "bradlc.vscode-tailwindcss",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "mikestead.dotenv",
+                "ms-azuretools.vscode-docker",
+                "GitHub.vscode-pull-request-github"
+            ],
+            "settings": {
+                "php.suggest.basic": false,
+                "editor.formatOnSave": true,
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "[php]": {
+                    "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+                },
+                "intelephense.environment.phpVersion": "8.4.0",
+                "intelephense.files.maxSize": 5000000,
+                "xdebug.remote_enable": true
+            }
+        }
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,4 +187,7 @@ ARG NODE_ENV=production
 RUN set -eux; \
 	apk add --no-cache \
 		make \
-		mysql-client
+		mysql-client; \
+	install-php-extensions xdebug
+
+COPY docker/php/conf.d/bewelcome.xdebug.ini $PHP_INI_DIR/conf.d/xdebug.ini

--- a/docker/php/conf.d/bewelcome.xdebug.ini
+++ b/docker/php/conf.d/bewelcome.xdebug.ini
@@ -1,0 +1,6 @@
+﻿; Xdebug configuration for development
+; Disabled by default for performance. To enable, you can set XDEBUG_MODE=debug
+xdebug.mode=off
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes
+xdebug.discover_client_host=1


### PR DESCRIPTION


### 🎯 What this does:
1. **Zero manual setup:** A contributor can clone the repo on this branch, click "Reopen in Container", and the environment will build and seed automatically using the `php` (php-fpm) container.
2. **Codespaces Ready:** Configured so anyone can spin up a free GitHub Codespace directly from this branch and have a working Rox environment in their browser.
3. **Xdebug added:** `xdebug` is installed in the `bewelcome_php_dev` stage and configured via `bewelcome.xdebug.ini` to allow easy local debugging out of the box (defaulted to `off` so it does not degrade performance during normal use).
4. **Ports:** Standard ports (80 for Web/Nginx, 1080 for Mailcatcher) are auto-forwarded and labelled for a cleaner experience.

*(Note: The previous PR #484 was against `develop`. This correctly targets `feature/docker-master` as requested by Peter.)*
