### PR TITLE
feat: Add DevContainer and Codespaces support for develop (FrankenPHP)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,61 @@
+{
+    "name": "BeWelcome Rox (Develop)",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../docker-compose.override.yml.dist"
+    ],
+    "service": "php",
+    "workspaceFolder": "/srv/bewelcome",
+    "overrideCommand": false,
+    "forwardPorts": [80, 1080, 9306, 9308],
+    "portsAttributes": {
+        "80": {
+            "label": "BeWelcome App (FrankenPHP)",
+            "onAutoForward": "openBrowser"
+        },
+        "1080": {
+            "label": "MailCatcher Web UI",
+            "onAutoForward": "notify"
+        },
+        "9306": {
+            "label": "Manticore MySQL protocol",
+            "onAutoForward": "silent"
+        },
+        "9308": {
+            "label": "Manticore HTTP API",
+            "onAutoForward": "silent"
+        }
+    },
+    "postCreateCommand": "bzip2 -ckd docker/languages.sql.bz2 > docker/db/languages.sql && bzip2 -ckd docker/words.sql.bz2 > docker/db/words.sql",
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "4gb",
+        "storage": "32gb"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bmewburn.vscode-intelephense-client",
+                "xdebug.php-debug",
+                "symfony-vscode.symfony-vscode",
+                "bradlc.vscode-tailwindcss",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "mikestead.dotenv",
+                "ms-azuretools.vscode-docker",
+                "GitHub.vscode-pull-request-github"
+            ],
+            "settings": {
+                "php.suggest.basic": false,
+                "editor.formatOnSave": true,
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "[php]": {
+                    "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+                },
+                "intelephense.environment.phpVersion": "8.4.0",
+                "intelephense.files.maxSize": 5000000,
+                "xdebug.remote_enable": true
+            }
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
             "onAutoForward": "openBrowser"
         },
         "1080": {
-            "label": "MailCatcher Web UI",
+            "label": "MailPit Web UI",
             "onAutoForward": "notify"
         },
         "9306": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,9 +192,11 @@ RUN set -eux; \
 	chmod a+w "$PHP_INI_DIR"; \
 	mkdir -p vendor var/cache var/log; \
 	chmod -R a+w vendor; \
-	chmod -R 777 var
+	chmod -R 777 var; \
+	install-php-extensions xdebug
 
 COPY docker/frankenphp/Caddyfile /etc/caddy/Caddyfile
+COPY docker/php/conf.d/bewelcome.xdebug.ini $PHP_INI_DIR/conf.d/xdebug.ini
 COPY docker/php/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,10 @@ services:
 #      - ./docker/manticore/manticore.conf:/etc/manticoresearch/manticore.conf
 
   mailer:
-    image: tophfr/mailcatcher
+    image: axllent/mailpit
+    environment:
+      MP_SMTP_BIND_ADDR: "0.0.0.0:25"
+      MP_UI_BIND_ADDR: "0.0.0.0:80"
 
 volumes:
   db-data: {}

--- a/docker/php/conf.d/bewelcome.xdebug.ini
+++ b/docker/php/conf.d/bewelcome.xdebug.ini
@@ -1,0 +1,6 @@
+; Xdebug configuration for development
+; Disabled by default for performance. To enable, you can set XDEBUG_MODE=debug
+xdebug.mode=off
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes
+xdebug.discover_client_host=1

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -106,9 +106,9 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
 		echo "Database created."
 
 		echo "Importing translations"
-		if [ -f docker/db/word.sql ]; then
+		if [ -f docker/db/words.sql ]; then
 			echo "Yepp, really. Importing translations"
-			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/word.sql
+			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/words.sql
 		fi
 		if [ -f docker/db/geonamesadminunits.sql ]; then
 			mariadb "$database_name" -u "$database_user" -p"$database_password" -h "$database_host" --port="$database_port" < docker/db/geonamesadminunits.sql


### PR DESCRIPTION
Following up on the discussion in #484, this PR adds the DevContainer setup for the \develop\ branch (FrankenPHP stack) so it can be tested in parallel with the \eature/docker-master\ stack (Nginx).
