### PR TITLE
feat(newsletter): add List-Unsubscribe headers and RFC 8058 one-click handler

### DIFF
--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -22,6 +22,12 @@ class SubscriptionController extends AbstractController
         string $username,
         string $unsubscribeKey
     ): Response {
+        if ($request->isMethod('POST') && 'List-Unsubscribe=One-Click' === $request->request->get('List-Unsubscribe')) {
+            $subscriptionModel->unsubscribeNewsletter($username, $unsubscribeKey);
+
+            return new Response('', Response::HTTP_OK);
+        }
+
         $form = $this->createForm(NewsletterUnsubscribeType::class);
         $form->handleRequest($request);
 

--- a/src/Service/Mailer.php
+++ b/src/Service/Mailer.php
@@ -133,7 +133,9 @@ class Mailer
             $parameters['sender'],
             $receiver,
             'newsletter',
-            $parameters
+            $parameters,
+            null,
+            $this->buildNewsletterHeaders($newsletter, $receiver, $parameters),
         );
     }
 
@@ -301,7 +303,7 @@ class Mailer
      *
      * @return bool
      */
-    private function sendTemplateEmail($sender, $receiver, string $template, array $parameters, ?string $replyTo = null): bool
+    private function sendTemplateEmail($sender, $receiver, string $template, array $parameters, ?string $replyTo = null, array $extraTextHeaders = []): bool
     {
         $currentLocale = $this->translator->getLocale();
         $success = true;
@@ -344,6 +346,10 @@ class Mailer
             $email->replyTo(new Address($replyTo));
         }
 
+        foreach ($extraTextHeaders as $name => $value) {
+            $email->getHeaders()->addTextHeader($name, $value);
+        }
+
         try {
             $this->mailer->send($email);
         } catch (TransportExceptionInterface $e) {
@@ -361,6 +367,36 @@ class Mailer
     {
         $language = $receiver->getPreferredLanguage();
         $this->translator->setLocale($language->getShortCode());
+    }
+
+    private function buildNewsletterHeaders(Newsletter $newsletter, Member $receiver, array $parameters): array
+    {
+        $transactionalTypes = [
+            'RemindToLog',
+            'MailToConfirmReminder',
+            Newsletter::SUSPENSION_NOTIFICATION,
+            Newsletter::TERMS_OF_USE,
+        ];
+        if (\in_array($newsletter->getType(), $transactionalTypes, true)) {
+            return [];
+        }
+
+        $unsubscribeKey = $parameters['unsubscribe_key'] ?? null;
+        if (null === $unsubscribeKey) {
+            return [];
+        }
+
+        $unsubscribeUrl = $this->urlGenerator->generate(
+            'regular_newsletter_unsubscribe',
+            ['username' => $receiver->getUsername(), 'unsubscribeKey' => $unsubscribeKey],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+
+        return [
+            'Precedence'            => 'bulk',
+            'List-Unsubscribe'      => '<' . $unsubscribeUrl . '>',
+            'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
+        ];
     }
 
     private function prepareParametersForNewsletter(Newsletter $newsletter, Member $receiver): array


### PR DESCRIPTION
## Summary

- **`Mailer::sendNewsletterEmail()`**: now emits three bulk-mail headers on every regular newsletter send:
  - `Precedence: bulk` — standard signal for mass mail
  - `List-Unsubscribe: <https://...>` — personalised per recipient using the existing unsubscribe token (required by Google/Yahoo since Feb 2024 for senders over 5,000/day)
  - `List-Unsubscribe-Post: List-Unsubscribe=One-Click` — enables Gmail's one-click unsubscribe button
- Transactional sends (reminder, suspension notification, Terms of Use) are excluded from bulk headers.
- **`SubscriptionController::unsubscribeNewsletter()`**: handles RFC 8058 one-click POST requests (body `List-Unsubscribe=One-Click`) sent by Gmail when a user clicks the unsubscribe button, immediately suppressing the address with a 200 response and no confirmation page.

## Implementation notes

`sendTemplateEmail()` gains an `array $extraTextHeaders = []` parameter (backward-compatible default). A new private `buildNewsletterHeaders()` method constructs the header map, returning empty for transactional types or when no unsubscribe key is present.

The unsubscribe URL is generated via the existing `regular_newsletter_unsubscribe` route with the per-recipient `unsubscribe_key` already passed through `SendMassmailCommand`.

## Test plan

- [ ] Send a test newsletter to a personal address; confirm `List-Unsubscribe`, `List-Unsubscribe-Post`, and `Precedence` appear in raw headers
- [ ] Verify the unsubscribe URL in the header resolves to the correct member's unsubscribe page
- [ ] POST to the unsubscribe URL with body `List-Unsubscribe=One-Click`; confirm 200 and that the member is unsubscribed
- [ ] Send a reminder/suspension notification; confirm none of the bulk headers appear