### PR TITLE
Fix landing dashboard tab and card seams

### DIFF
--- a/assets/scss/bewelcome.scss
+++ b/assets/scss/bewelcome.scss
@@ -213,7 +213,7 @@
         right: 0;
         bottom: calc(-1 * #{$nav-tabs-border-width});
         left: 0;
-        height: $nav-tabs-border-width;
+        height: calc(2 * #{$nav-tabs-border-width});
         background-color: $white;
         content: "";
       }

--- a/assets/scss/bewelcome.scss
+++ b/assets/scss/bewelcome.scss
@@ -175,6 +175,55 @@
     }
   }
 
+  .landing-dashboard-tabs {
+    position: relative;
+    z-index: 1;
+    border-bottom: 0;
+
+    .nav-link {
+      font-family: "Signika", sans-serif;
+      border-color: transparent;
+      border-radius: 8px 8px 0 0;
+      transition: color .15s ease-in-out, background-color .15s ease-in-out;
+
+      &:not(.active):hover,
+      &:not(.active):focus {
+        background-color: rgba($brand-primary, .1);
+        border-color: transparent;
+      }
+
+      &:focus-visible {
+        position: relative;
+        z-index: 2;
+        outline: 0;
+        box-shadow: inset 0 3px rgba($brand-primary, .65);
+      }
+    }
+
+    .nav-link.active,
+    .nav-item.show .nav-link {
+      position: relative;
+      margin-bottom: 0;
+      padding-bottom: calc(var(--bs-nav-link-padding-y) + var(--bs-border-width));
+      border-color: $nav-tabs-border-color $nav-tabs-border-color transparent;
+      border-bottom-width: 0;
+
+      &::after {
+        position: absolute;
+        right: 0;
+        bottom: calc(-1 * #{$nav-tabs-border-width});
+        left: 0;
+        height: $nav-tabs-border-width;
+        background-color: $white;
+        content: "";
+      }
+    }
+  }
+
+  .landing-dashboard-card {
+    border: $nav-tabs-border-width solid $nav-tabs-border-color;
+  }
+
   #editProfileTab .nav-tabs {
     display: none;
   }

--- a/templates/landing/landing.html.twig
+++ b/templates/landing/landing.html.twig
@@ -78,7 +78,7 @@
 	{# conversations box #}
 	<div class="u:w-full u:flex u:flex-col">
 
-        <ul class="nav nav-tabs" role="tablist">
+        <ul class="nav nav-tabs landing-dashboard-tabs" role="tablist">
             <li class="nav-item">
                 <a class="nav-link active" aria-controls="conversations" href="#conversations" role="tab"
                    data-bs-toggle="tab">{{ 'landing.tab.messagesreceived' | trans }}
@@ -98,7 +98,7 @@
             </li>
         </ul>
 
-        <div class="o-card o-card--tabbed tab-content u:p-16 u:bg-white">
+        <div class="o-card o-card--tabbed landing-dashboard-card tab-content u:p-16 u:bg-white">
 
 			{# conversations #}
 			<div role="tabpanel" class="o-tab tab-pane u:h-full active" id="conversations">
@@ -171,7 +171,7 @@
 	{# community box #}
 	<div class="u:w-full u:flex u:flex-col">
 
-		<ul class="nav nav-tabs" role="tablist">
+		<ul class="nav nav-tabs landing-dashboard-tabs" role="tablist">
 			<li class="nav-item">
           <a href="#threads" class="nav-link active" aria-controls="threads" role="tab"
              data-bs-toggle="tab">{{ 'landing.tab.forum' | trans }}</a>
@@ -188,7 +188,7 @@
             </li>
 		</ul>
 
-		<div class="o-card o-card--tabbed tab-content u:p-16">
+		<div class="o-card o-card--tabbed landing-dashboard-card tab-content u:p-16">
 			{# forum discussions #}
 			<div role="tabpanel" class="o-tab tab-pane u:h-full active" id="threads">
 


### PR DESCRIPTION
## Summary

Fixes #474.
@elcreator, would you be able to review the visual changes?

The active tabs on the logged-in landing dashboard were visually separated from their content cards. The tab-list border also formed a straight top edge that did not follow the card’s rounded corner.

## Changes

- Move the visible top border onto the rounded dashboard card.
- Join the active tab to the card by overlapping the border.
- Clean up the active tab’s focus styling.
- Scope the changes to the landing dashboard so other tabs are unaffected.

## Testing

- Tested both dashboard tab groups.
- Tested switching between all tabs.
- Verified the active tab joins cleanly with its content.
- Verified the card border follows the rounded top-right corner.
- Verified keyboard focus remains visible.

## Screenshots

### Before 

(Mentioned)
<img width="553" height="243" alt="image" src="https://github.com/user-attachments/assets/969d7a19-891a-40aa-aae0-7f7b457832b2" />

(Latest build)
<img width="1245" height="588" alt="Screenshot 2026-09-01 at 9 39 06 AM" src="https://github.com/user-attachments/assets/8b9b8724-6f41-4f92-9574-932c96e9bda7" />


### After

<img width="951" height="355" alt="Screenshot 2026-09-01 at 9 31 55 AM" src="https://github.com/user-attachments/assets/0f39f595-ed5e-43a3-a183-3dea846f567a" />
