### PR TITLE
docs: make DevContainer the primary recommended setup method

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,22 @@
+# DevContainer
+
+This directory configures a VS Code [Dev Container](https://containers.visualstudio.com/docs/devcontainer/) for local Rox development. See [INSTALL.md](../INSTALL.md) for full setup instructions.
+
+## Quick reference
+
+| Service | Address |
+|---|---|
+| BeWelcome app | `http://localhost` |
+| Mailpit (catch-all mailer) | `http://localhost:1080` |
+| Manticore HTTP API | `http://localhost:9308` |
+| Manticore MySQL protocol | `localhost:9306` |
+
+Default login: `member-2` / `password`
+
+## macOS + Rancher Desktop
+
+If pages hang when accessing `localhost:1080` or `localhost:80`, remove the `forwardPorts` key from `devcontainer.json` and rebuild the container (**Ctrl+Shift+P → Dev Containers: Rebuild Container**). Rancher Desktop uses SSH tunnelling to expose container ports, which conflicts with VS Code's additional port-forwarding layer. Removing `forwardPorts` lets Rancher handle it directly. This does not affect WSL or Docker Desktop.
+
+## GitHub Codespaces
+
+Open the repository on GitHub and choose **Code → Codespaces → Create codespace on master** to run the full stack in the cloud without any local installation.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ The repository ships a `.devcontainer` configuration that sets up the full stack
 ### Requirements
 
 - [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-- [Docker](https://docs.docker.com/get-docker/) (Docker Desktop, Rancher Desktop, or equivalent)
+- [Docker](https://docs.docker.com/get-docker/) (Engine + CLI — Docker Desktop or Rancher Desktop on macOS/Windows; Docker Engine directly on Linux)
 
 ### Start
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,203 +1,168 @@
-# Installation of BW-Rox
+# Getting started with Rox development
 
-1. Clone via Git:
+There are three ways to run a local Rox development environment, listed from easiest to most involved.
 
-    ```bash
-    $ git clone https://github.com/BeWelcome/rox.git
-    ```
+## A) VS Code DevContainer (recommended)
 
-    For a first look around a read-only clone will do. If you want to support development please fork the repository and send pull requests.
-
-2. You can choose to install using A) Docker and Docker Compose or B) Installation step by step of BW-Rox (GNU/Linux) (see below)
-
-## A) Install using Docker and Docker Compose
-
-The docker configuration is still in-progress, and is currently missing the setup of the sphinx search functionality (essential for using all of the search functionality in the app). Until configuration is complete, local installation is recommended. 
+The repository ships a `.devcontainer` configuration that sets up the full stack — PHP 8.2, Nginx, MariaDB, Manticore Search, and Mailpit — automatically inside a container. No manual dependency installation needed.
 
 ### Requirements
 
-* [Docker](https://docs.docker.com/get-docker/)
-* [Docker Compose](https://docs.docker.com/compose/install/)
-* If running on Windows, we recommend installing WSL in order to execute the following linux commands. Note that the files of the repository should be put into the WSL file share and not below your user directory or someplace else easily accessible by Windows.
+- [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- [Docker](https://docs.docker.com/get-docker/) (Docker Desktop, Rancher Desktop, or equivalent)
 
-### Initialize installation
+### Start
 
-1. Install using Docker and Docker Compose:
-
-    ```bash
-    $ make install
-    ```
-
-   If you need to run Docker Compose as sudo, run the following:
+1. Clone the repository and open it in VS Code:
 
     ```bash
-    $ make install root=1
-    ```
-    
-    <details>
-    <summary><strong>Troubleshooting</strong></summary>
-
-      Windows users may run into a build error concerning `composer clear-cache`. If you see this error, please try the following:
-        * If you receive the error when running `make install`, try running `make install root=1`. Make sure to run the command with `root=1` after trying each of the following steps as well
-        * Ensure that you are using WSL version 2 for your linux distro ([how to upgrade from WSL 1 to WSL 2](https://docs.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2))
-        * Use Ubuntu 22.04 LTS as your linux distro - the error has been observed on earlier versions of Ubuntu, e.g. on 18.04 LTS
-
-    </details>
-
-Wait a few minutes for containers to build and start (it might take awhile). Project is running at
-[http://localhost:8080](http://localhost:8080). If you see a "502 Bad Gateway" error in your browser, the app is still being built, and should serve the page without error once all processes finish.
-
-2. If you want to import geonames data, run the following (this operation takes awhile!):
-
-    ```bash
-    $ make install-geonames
+    git clone https://github.com/BeWelcome/rox.git
+    code rox
     ```
 
-    Once again, if you need to run Docker Compose as sudo, run the following:
+2. VS Code will detect the `.devcontainer` configuration and prompt **"Reopen in Container"** — click it. The first run builds the images and imports seed data; expect 5–10 minutes.
 
-    ```bash
-    $ make install-geonames root=1
-    ```
+3. Once the container is ready, VS Code opens a browser tab at `http://localhost` automatically. Log in with username `member-2` and password `password`.
 
-Please read [Useful hints](#useful-hints) section below.
+### GitHub Codespaces
 
-## B) Installation step by step of BW-Rox (GNU/Linux)
+You can also run the devcontainer in the cloud without installing anything locally: open the repository on GitHub and choose **Code → Codespaces → Create codespace on master**.
 
-These steps have been tested on Debian/Ubuntu based systems. Commands,
-usernames and locations might differ on your distribution.
+### Accessing services
 
-Windows users may use XAMPP and execute most of the commands in the git bash.
-Commands for mysql need to be run in the XAMPP shell. Instead of wget either download
-using a browser or use curl _url_ > _filename_.
+| Service | URL |
+|---|---|
+| BeWelcome app | `http://localhost` |
+| Mailpit (catch-all mailer) | `http://localhost:1080` |
+| Manticore HTTP API | `http://localhost:9308` |
+
+### macOS + Rancher Desktop note
+
+On macOS with Rancher Desktop, `forwardPorts` in `devcontainer.json` can cause VS Code to intercept connections before Rancher's port tunnel reaches the container, resulting in pages that hang indefinitely. If you hit this, remove the `forwardPorts` key from `.devcontainer/devcontainer.json` and rebuild the container — VS Code auto-detects host-mapped ports from the compose file anyway. This does not affect WSL or Docker Desktop users.
+
+---
+
+## B) Docker Compose directly
+
+If you prefer not to use VS Code, you can bring the stack up manually.
 
 ### Requirements
 
-* Apache with mod_rewrite enabled
-* PHP version >= 7.4 < 8.0
-* [PHP GD lib enabled](https://www.php.net/manual/en/image.installation.php)
-* PHP extensions: mbstring, xml, fileinfo, intl, xsl, xmlrpc (see composer.json)
-  * note that the xml extension does not need to be installed on Windows as it is [installed by default](https://www.php.net/manual/en/xml.installation.php)
-* MariaDB >=10.1
-* [symfony command line interface](https://symfony.com/download) (download/setup)
-* SMTP server for email features
-* [Composer](https://www.getcomposer.org) Version 2 (installed globally)
-* [Node.js](https://nodejs.org/) Latest version (installed globally)
-* [Yarn](https://classic.yarnpkg.com/en/docs/install/) Latest version
-* [Sphinxsearch](http://sphinxsearch.com/) Version 3
-* wget (if you want to follow the instructions word to word) otherwise curl and the -o parameter should be your friend
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/) (v2)
 
-### Initialize installation
+### Start
 
-1. Install the rox dependencies using composer and yarn
+1. Clone the repository:
 
     ```bash
-    $ composer install
-    $ yarn install --frozen-lock
+    git clone https://github.com/BeWelcome/rox.git
+    cd rox
     ```
 
-2. Initialize the database.
-
-    Copy .env into a .env.local file and edit the DB_HOST to point to localhost (assuming MariaDB runs locally).
-
-    In mysql create a new global user `bewelcome` with password `bewelcome`.
-
-    This generates a new database as given in the ```.env.local``` file and presets some data.
+2. Copy the override template and bring everything up:
 
     ```bash
-    $ php bin/console test:database:create --drop --force
+    cp docker-compose.override.yml.dist docker-compose.override.yml
+    docker compose up -d
     ```
 
-### Test and log in
+   The first run downloads images and imports seed data. Wait until `docker compose logs -f php` shows `ready to handle connections`.
 
-1. Run
+3. Open `http://localhost` in your browser. Log in with `member-2` / `password`.
 
-   ```bash
-    $ make build version
-   ```
+> **Windows users:** place the repository inside the WSL filesystem (not under a Windows drive path) to avoid volume-mount performance issues. Run all commands from a WSL terminal.
 
-   to build the CSS and JS files. The version creates a file referenced in the footer.
+### Useful Makefile targets
 
-2. Build sphinx indices and run search daemon
+```bash
+make build          # compile CSS and JS assets
+make install        # first-time setup (runs docker compose up + asset build)
+make phpcsfix       # auto-fix PHP coding standard issues
+```
 
-   Adapt setup/sphinx/sphinx-3.conf to match your needs: update DB credentials and replace all occurences of <path to indices> with the path to your sphinx indexes folder (or other folder of your preference), e.g. `C:/Program Files/Sphinx/sphinxdata/indexes`
+---
 
-   Run the indexer to create indices:
-   ```bash
-   $ indexer --config indices-3.conf --all
-   ```
+## C) Manual installation (advanced)
 
-   Serve the indices using the search daemon:
-   ```bash
-   $ searchd --config indices-3.conf
-   ```
+For contributors who need to debug at the OS level or cannot use Docker.
 
-3. Start the server
+Tested on Debian/Ubuntu. Adapt paths and commands for other distributions.
 
-   ```bash
-    $ symfony serve
-   ```
+### Requirements
 
-   Access the site using http://localhost:8000/ or with https://localhost:8000/ (if you installed certificate for symfony)
+- PHP 8.2 with extensions: `mbstring`, `xml`, `fileinfo`, `intl`, `xsl`, `gd`, `apcu`
+- MariaDB >= 10.5
+- [Manticore Search](https://manticoresearch.com/) 6.x
+- [Composer](https://getcomposer.org/) v2
+- [Node.js](https://nodejs.org/) LTS + [Yarn](https://classic.yarnpkg.com/)
+- An SMTP relay (e.g. Mailpit, Postfix, or any local MTA)
 
-Please read [Useful hints](#useful-hints) section below.
+### Initialize
 
-3. (Optional) Load languages and translations
+1. Install PHP dependencies:
 
     ```bash
-    $ wget https://downloads.bewelcome.org/for_developers/rox_test_db/languages.sql.bz2
-    $ wget https://downloads.bewelcome.org/for_developers/rox_test_db/words.sql.bz2
-    $ bunzip2 languages.sql.bz2 words.sql.bz2
-    $ mysql bewelcome -u bewelcome -pbewelcome < languages.sql
-    $ mysql bewelcome -u bewelcome -pbewelcome < words.sql
+    composer install
     ```
 
-4. (Optional) Load geonames database (this operation takes awhile!)
+2. Copy `.env` to `.env.local` and set `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and `MAILER_DSN` to match your local setup.
+
+3. Create and seed the database:
 
     ```bash
-    $ wget http://download.geonames.org/export/dump/allCountries.zip > docker/db/allCountries.zip
-    $ wget http://download.geonames.org/export/dump/alternateNames.zip > docker/db/alternateNames.zip
-    $ wget http://download.geonames.org/export/dump/countryInfo.txt > docker/db/countryInfo.txt
-    $ unzip docker/db/allCountries.zip -d docker/db/
-    $ unzip docker/db/alternateNames.zip -d docker/db/
-    $ rm docker/db/*.zip
-    $ mysql bewelcome -u bewelcome -pbewelcome < import.sql
+    php bin/console test:database:create --drop --force
     ```
 
-    After this you should rebuilt the indices for sphinx:
-   ```bash
-   $ /usr/bin/indexer --config indices-3.conf --rotate --quiet --all
-   ```
-
-## Useful hints
-
-* Log in as user `member-2` and password `password`.  There is also a user bwadmin which has some rights assigned (and uses the same password).
-
-* Click around the site a bit and check if all CSS and images are loaded.
-   Refer to var/log/dev.log if errors appear or something looks broken. Also make use of the Symfony debug toolbar.
-
-* Geographical data (without optional geonames database):
-
-    There are exactly two cities in the dump: Berlin and Jayapura.
-
-* Resetting all user passwords:
+4. (Optional) Import language and translation data:
 
     ```bash
-    $ mysql bewelcome -u bewelcome -pbewelcome
+    wget https://downloads.bewelcome.org/for_developers/rox_test_db/languages.sql.bz2
+    wget https://downloads.bewelcome.org/for_developers/rox_test_db/words.sql.bz2
+    bunzip2 languages.sql.bz2 words.sql.bz2
+    mysql bewelcome -u bewelcome -pbewelcome < languages.sql
+    mysql bewelcome -u bewelcome -pbewelcome < words.sql
     ```
 
-    ```sql
-    mysql> UPDATE members SET password = PASSWORD('password');
-    mysql> exit;
-    ```
-
-* When doing bigger updates clear the cache from time to time with
+5. Install JS dependencies and compile assets:
 
     ```bash
-    $ php bin/console cache:clear
+    yarn install --frozen-lock
+    make build
     ```
 
-* Production OS is Debian GNU/Linux Strech.
+6. Start the development server:
 
-## Create documentation
+    ```bash
+    symfony serve
+    ```
 
-If you need documentation check out [MKDocs](https://www.mkdocs.org/).
+   Access the site at `https://localhost:8000/`. Log in with `member-2` / `password`.
+
+---
+
+## After any update
+
+When `composer.json` or `composer.lock` changes:
+
+```bash
+composer install --prefer-dist --no-progress --no-interaction --no-scripts
+```
+
+When `package.json` or `yarn.lock` changes:
+
+```bash
+yarn install --frozen-lock
+```
+
+When any `.scss` file or file in `assets/` changes:
+
+```bash
+make build
+```
+
+When you want to clear the Symfony cache:
+
+```bash
+php bin/console cache:clear
+```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@
 
 You like the idea? Development is only one way to contribute! Find out how to [get active](https://www.bewelcome.org/about/getactive), including as designer, tester, translator, moderator, helping others and much more! :heart_eyes:
 
-## Get your Rox development enviroment :computer:
+## Get your Rox development environment :computer:
 
-1. :balloon: [Set up you local development enviroment](INSTALL.md) and fork the repository on Github.
+The fastest way to start is with VS Code DevContainers — one click sets up PHP, MariaDB, Manticore Search, and a local mailer automatically. GitHub Codespaces works too if you prefer not to install anything locally.
+
+1. :balloon: [Set up your local development environment](INSTALL.md) (DevContainer recommended) and fork the repository on GitHub.
 2. :mag: Pick a [good starter issue](https://github.com/BeWelcome/rox/labels/good%20starter%20issue)
 3. :sparkles: Create a [pull request](https://opensource.guide/how-to-contribute/#opening-a-pull-request) and `@mention` the people from the issue to review
 4. :sun_with_face: Fix the remaining things during review
-4. :tada: Wait for it being merged!
+5. :tada: Wait for it being merged!
 
 You probably want to get started by checking out the code in `src/`.
 


### PR DESCRIPTION
## Summary

- **INSTALL.md** rewritten: DevContainer is now method A (replaces the old Docker section that called itself "still in-progress" and warned Manticore wasn't set up — it is now). Docker Compose directly is method B. Manual install kept as method C (advanced/legacy) with updated PHP requirement to 8.2.
- **README.md** updated: "Get your development environment" section mentions DevContainer and Codespaces upfront before pointing to INSTALL.md.
- **`.devcontainer/README.md`** added: quick-reference table for service URLs, macOS + Rancher Desktop `forwardPorts` workaround, Codespaces note.

## macOS + Rancher Desktop note (documented)

On macOS with Rancher Desktop, `forwardPorts` in `devcontainer.json` creates a competing `localhost:PORT` listener that intercepts connections before Rancher's SSH tunnel reaches the container, causing pages to hang. Workaround: remove `forwardPorts` from `devcontainer.json` and rebuild. Works fine on WSL and Docker Desktop without this change. Tested by Neophytis.